### PR TITLE
[Feat] 타임스탬프 동기화 방식으로 box처리 기능 추가

### DIFF
--- a/BE/app/api/bbox.py
+++ b/BE/app/api/bbox.py
@@ -1,0 +1,58 @@
+import json
+from typing import Any
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+router = APIRouter(tags=["bbox"])
+
+
+class BboxManager:
+    def __init__(self):
+        # camera_id → 연결된 프론트 WebSocket 목록
+        self._clients: dict[str, list[WebSocket]] = {}
+
+    async def connect(self, camera_id: str, ws: WebSocket):
+        await ws.accept()
+        self._clients.setdefault(camera_id, []).append(ws)
+
+    def disconnect(self, camera_id: str, ws: WebSocket):
+        clients = self._clients.get(camera_id, [])
+        if ws in clients:
+            clients.remove(ws)
+
+    async def broadcast(self, camera_id: str, data: Any):
+        dead = []
+        for ws in self._clients.get(camera_id, []):
+            try:
+                await ws.send_text(json.dumps(data))
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            self.disconnect(camera_id, ws)
+
+
+bbox_manager = BboxManager()
+
+
+@router.websocket("/ws/bbox/{camera_id}")
+async def bbox_ws(camera_id: str, websocket: WebSocket):
+    """프론트엔드 연결 — bbox 데이터를 수신해서 화면에 그림"""
+    await bbox_manager.connect(camera_id, websocket)
+    try:
+        while True:
+            await websocket.receive_text()  # 연결 유지용
+    except WebSocketDisconnect:
+        bbox_manager.disconnect(camera_id, websocket)
+
+
+@router.websocket("/ws/bbox/{camera_id}/push")
+async def bbox_push_ws(camera_id: str, websocket: WebSocket):
+    """AI 서버 연결 — bbox 데이터를 push하면 프론트로 브로드캐스트"""
+    await websocket.accept()
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            data = json.loads(raw)
+            await bbox_manager.broadcast(camera_id, data)
+    except WebSocketDisconnect:
+        pass

--- a/BE/app/main.py
+++ b/BE/app/main.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse
 import app.models  # noqa: F401 — 모든 모델을 SQLAlchemy에 등록
 
 from app.api.auth import router as auth_router
+from app.api.bbox import router as bbox_router
 from app.api.camera import router as camera_router
 from app.api.internal import router as internal_router
 from app.api.stream import router as stream_router
@@ -55,6 +56,7 @@ def readiness_check():
 
 
 app.include_router(auth_router)
+app.include_router(bbox_router)
 app.include_router(camera_router)
 app.include_router(stream_router)
 app.include_router(user_router)

--- a/fe/src/components/BboxOverlay.tsx
+++ b/fe/src/components/BboxOverlay.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from "react";
+
+interface Box {
+  x: number; y: number; w: number; h: number;
+  label: string; conf: number;
+}
+
+interface BboxFrame {
+  wall_time: number;
+  boxes: Box[];
+}
+
+interface Props {
+  cameraId: string;
+  getLatency: () => number;
+}
+
+const WS_BASE = import.meta.env.VITE_API_URL
+  ? import.meta.env.VITE_API_URL.replace(/^http/, "ws")
+  : `ws://${window.location.host}`;
+
+const BboxOverlay = ({ cameraId, getLatency }: Props) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const bufferRef = useRef<BboxFrame[]>([]);
+  const getLatencyRef = useRef(getLatency);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    getLatencyRef.current = getLatency;
+  }, [getLatency]);
+
+  // WebSocket: fill buffer
+  useEffect(() => {
+    const ws = new WebSocket(`${WS_BASE}/ws/bbox/${cameraId}`);
+    ws.onopen = () => setConnected(true);
+    ws.onclose = () => setConnected(false);
+
+    ws.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      const boxes: Box[] = data.boxes ?? [];
+
+      if (data.wall_time !== undefined) {
+        const frame: BboxFrame = { wall_time: data.wall_time, boxes };
+        const buf = bufferRef.current;
+        // Insert maintaining ascending wall_time order
+        let i = buf.length;
+        while (i > 0 && buf[i - 1].wall_time > frame.wall_time) i--;
+        buf.splice(i, 0, frame);
+        // Prune entries older than 15s
+        const cutoff = Date.now() / 1000 - 15;
+        while (buf.length > 0 && buf[0].wall_time < cutoff) buf.shift();
+      } else {
+        // No timestamp: treat as "now" for backward compat
+        bufferRef.current = [{ wall_time: Date.now() / 1000, boxes }];
+      }
+    };
+
+    return () => ws.close();
+  }, [cameraId]);
+
+  // Animation loop: find frame matching current displayed wall time
+  useEffect(() => {
+    let rafId: number;
+
+    const drawBoxes = (boxes: Box[]) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      boxes.forEach((box) => {
+        const x = box.x * canvas.width;
+        const y = box.y * canvas.height;
+        const w = box.w * canvas.width;
+        const h = box.h * canvas.height;
+
+        ctx.strokeStyle = "#ef4444";
+        ctx.lineWidth = 2;
+        ctx.strokeRect(x, y, w, h);
+
+        const label = `${box.label} ${(box.conf * 100).toFixed(0)}%`;
+        ctx.font = "bold 12px monospace";
+        const tw = ctx.measureText(label).width;
+        ctx.fillStyle = "#ef4444";
+        ctx.fillRect(x, y - 18, tw + 8, 18);
+        ctx.fillStyle = "#fff";
+        ctx.fillText(label, x + 4, y - 4);
+      });
+    };
+
+    const loop = () => {
+      const buf = bufferRef.current;
+      if (buf.length > 0) {
+        // The frame currently shown on screen was captured at this wall time
+        const displayedWallTime = Date.now() / 1000 - getLatencyRef.current();
+
+        // Find the last buffered frame at or before the displayed wall time
+        let target: BboxFrame | null = null;
+        for (let i = buf.length - 1; i >= 0; i--) {
+          if (buf[i].wall_time <= displayedWallTime) {
+            target = buf[i];
+            break;
+          }
+        }
+
+        if (target) {
+          drawBoxes(target.boxes);
+        } else {
+          // All frames are ahead of playback; clear canvas
+          const canvas = canvasRef.current;
+          const ctx = canvas?.getContext("2d");
+          if (ctx && canvas) ctx.clearRect(0, 0, canvas.width, canvas.height);
+        }
+      }
+      rafId = requestAnimationFrame(loop);
+    };
+
+    rafId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafId);
+  }, []);
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        width={1280}
+        height={720}
+        style={{
+          position: "absolute", inset: 0,
+          width: "100%", height: "100%",
+          pointerEvents: "none", zIndex: 2,
+        }}
+      />
+      {connected && (
+        <div style={{
+          position: "absolute", bottom: 8, right: 8,
+          fontSize: 10, color: "#4ade80", background: "rgba(0,0,0,.5)",
+          padding: "2px 6px", borderRadius: 3, zIndex: 3,
+        }}>
+          AI 연결됨
+        </div>
+      )}
+    </>
+  );
+};
+
+export default BboxOverlay;

--- a/fe/src/components/VideoPlayer.tsx
+++ b/fe/src/components/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import Hls from "hls.js";
 
 interface Props {
@@ -6,9 +6,17 @@ interface Props {
   mediaServerUrl: string;
 }
 
-const VideoPlayer = ({ hlsUrl, mediaServerUrl }: Props) => {
+export interface VideoPlayerHandle {
+  getLatency: () => number;
+}
+
+const VideoPlayer = forwardRef<VideoPlayerHandle, Props>(({ hlsUrl, mediaServerUrl }, ref) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const hlsRef = useRef<Hls | null>(null);
+
+  useImperativeHandle(ref, () => ({
+    getLatency: () => hlsRef.current?.latency ?? 5,
+  }));
 
   useEffect(() => {
     const video = videoRef.current;
@@ -62,6 +70,7 @@ const VideoPlayer = ({ hlsUrl, mediaServerUrl }: Props) => {
       playsInline
     />
   );
-};
+});
 
+VideoPlayer.displayName = "VideoPlayer";
 export default VideoPlayer;

--- a/fe/src/pages/StreamPage.tsx
+++ b/fe/src/pages/StreamPage.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { getCameras, startStream, stopStream, getStreamStatus } from "../api/camera";
 import type { Camera, StreamStatus } from "../api/camera";
 import VideoPlayer from "../components/VideoPlayer";
+import type { VideoPlayerHandle } from "../components/VideoPlayer";
+import BboxOverlay from "../components/BboxOverlay";
 import Layout from "../components/Layout";
 
 const MEDIA_SERVER_URL = import.meta.env.VITE_MEDIA_SERVER_URL || "";
 
 const StreamPage = () => {
+  const videoPlayerRef = useRef<VideoPlayerHandle>(null);
+  const getLatency = () => videoPlayerRef.current?.getLatency() ?? 5;
+
   const [cameras, setCameras] = useState<Camera[]>([]);
   const [selected, setSelected] = useState<Camera | null>(null);
   const [streamStatus, setStreamStatus] = useState<StreamStatus | null>(null);
@@ -142,7 +147,12 @@ const StreamPage = () => {
                   </div>
                 )}
                 {hlsUrl
-                  ? <VideoPlayer hlsUrl={hlsUrl} mediaServerUrl={MEDIA_SERVER_URL} />
+                  ? (
+                    <>
+                      <VideoPlayer ref={videoPlayerRef} hlsUrl={hlsUrl} mediaServerUrl={MEDIA_SERVER_URL} />
+                      <BboxOverlay cameraId={selected.cameraId} getLatency={getLatency} />
+                    </>
+                  )
                   : (
                     <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 8, color: "rgba(255,255,255,.5)" }}>
                       <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">

--- a/fe/vite.config.ts
+++ b/fe/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       '/api': 'http://43.201.17.169:8000',
       '/internal': 'http://43.201.17.169:8000',
       '/hls': 'http://3.35.171.137:9000',
+      '/ws': { target: 'ws://43.201.17.169:8000', ws: true },
     }
   }
 })


### PR DESCRIPTION
## 🚀 변경 사항
실시간 bbox 오버레이 파이프라인을 구현한다. AI 서버에서 YOLO 추론 결과(bbox 좌표)를 WebSocket으로 BE에 전달하고, 프론트엔드에서 HLS 영상 위에 Canvas 오버레이로 실시간 바운딩 박스를 렌더링한다.

## 🧩 작업 내용
- [ ] `WS /ws/bbox/{camera_id}` WebSocket 엔드포인트 구현
- [ ] 카메라별 bbox 브로드캐스트 구조 구현 (연결된 클라이언트에 전파)
- [ ] AI 서버 → BE WebSocket 수신 및 프론트 브로드캐스트 로직 구현
- [ ] bbox 메시지 포맷 정의 `{ camera_id, timestamp, boxes: [{x, y, w, h, label, confidence}] }`
- [ ] YOLO 추론 후 영상 재인코딩 없이 좌표만 추출하여 BE WebSocket으로 전송
- [ ] 테스트용 가짜 bbox 좌표 전송 스크립트 작성 (YOLO 없이 랜덤 좌표 0.1초마다 전송)
- [ ] `StreamPage`에 `<video>` 위에 `<canvas>` 오버레이 레이어 추가
- [ ] WebSocket 연결 및 bbox 메시지 수신 훅 구현
- [ ] Canvas에 bbox 및 label 실시간 렌더링 구현
- [ ] 영상 해상도 기준 좌표 정규화 처리 (0~1 비율값 → 실제 픽셀 변환)

## 📝 참고 사항
영상 재인코딩 없이 bbox 좌표만 WebSocket으로 전송하여 지연 없는 실시간 객체 감지 시각화를 제공한다. HLS로 영상을 수신하고, WebSocket으로 좌표만 수신하여 Canvas 레이어에 오버레이함으로써 네트워크 부하를 최소화한다.