### PR TITLE
[Feat] overlap051 relabeling 및 Bedrock VLM 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,14 @@ AI/ai_pipeline/data/
 AI/ai_pipeline/outputs/
 AI/ai_pipeline/bigru_frame_selector/outputs/
 *.npy
+AI/slowfast/outputs/
 PGL-SUM/data/
 PGL-SUM/Summaries/
 storage/
+
+# 로그 및 결과 파일
 *.csv
+*.log
 
 # 영상 파일
 *.mp4

--- a/AI/slowfast/configs/eval_event_overlap051_bedrock_haiku.yaml
+++ b/AI/slowfast/configs/eval_event_overlap051_bedrock_haiku.yaml
@@ -1,0 +1,75 @@
+project:
+  output_root: /home/deepgu/slowfast/outputs/eval/event_compare/overlap051_bedrock_haiku
+
+clip:
+  temporal_window_sec: 2.0
+  stride_sec: 1.0
+  sampled_frames: 13
+  resize:
+    width: 160
+    height: 160
+  sampling: uniform
+
+fast_model:
+  device: auto
+  architecture: x3d_s
+  checkpoint_path: /home/deepgu/slowfast/outputs/train/overlap051_e20/x3d_s_fast_model_best.pt
+  num_classes: 1
+  input_clip_length: 13
+  input_crop_size: 160
+  batch_size: 8
+  use_pretrained_backbone: false
+  fallback_mode: heuristic
+  amp: true
+  use_pos_weight: true
+
+data_loader:
+  num_workers: 8
+  pin_memory: true
+  persistent_workers: true
+
+router:
+  prob_low: 0.30
+  prob_high: 0.55
+  uncertainty_threshold: 0.0
+  topk_ratio: 0.15
+  use_topk: false
+  alpha_entropy: 0.7
+  alpha_variance: 0.3
+  variance_window: 5
+
+vlm:
+  provider: bedrock
+  sampled_frames: 6
+  prompt_style: binary_fight
+  enabled: true
+  model_id: us.anthropic.claude-haiku-4-5-20251001-v1:0
+  region: us-east-1
+  max_tokens: 256
+
+fusion:
+  fast_weight: 0.5
+  vlm_weight: 0.5
+  only_when_vlm_called: true
+  suppression_bound:
+    enabled: true
+    max_drop: 0.12
+    protect_above_score: 0.42
+    protect_floor_score: 0.36
+
+thresholds:
+  start_score: 0.47
+  end_score: 0.42
+  min_event_duration_sec: 0.5
+  split:
+    enabled: true
+    score_threshold: 0.33
+    min_consecutive_clips: 2
+  score_smoothing:
+    enabled: true
+    window_size: 3
+    method: moving_average
+
+outputs:
+  save_clip_manifest: true
+  save_frame_samples: false

--- a/AI/slowfast/configs/eval_event_overlap051_e20.yaml
+++ b/AI/slowfast/configs/eval_event_overlap051_e20.yaml
@@ -1,0 +1,87 @@
+project:
+  output_root: /home/deepgu/slowfast/outputs/eval/event_compare/overlap051_e20
+
+clip:
+  temporal_window_sec: 2.0
+  stride_sec: 1.0
+  sampled_frames: 13
+  resize:
+    width: 160
+    height: 160
+  sampling: uniform
+
+fast_model:
+  device: auto
+  architecture: x3d_s
+  checkpoint_path: /home/deepgu/slowfast/outputs/train/overlap051_e20/x3d_s_fast_model_best.pt
+  num_classes: 1
+  input_clip_length: 13
+  input_crop_size: 160
+  batch_size: 8
+  use_pretrained_backbone: false
+  fallback_mode: heuristic
+  amp: true
+  use_pos_weight: true
+
+data_loader:
+  num_workers: 8
+  pin_memory: true
+  persistent_workers: true
+
+router:
+  prob_low: 0.40
+  prob_high: 0.60
+  uncertainty_threshold: 0.25
+  topk_ratio: 0.15
+  use_topk: false
+  alpha_entropy: 0.7
+  alpha_variance: 0.3
+  variance_window: 5
+
+vlm:
+  provider: internvl
+  sampled_frames: 6
+  prompt_style: binary_fight
+  enabled: true
+  repo_path: /home/deepgu/VERA/InternVL/internvl_chat
+  model_path: /home/deepgu/.cache/huggingface/hub/models--OpenGVLab--InternVL2-8B/snapshots/6fb9ad6924f69424e57fab2ab061d707688f0296
+  local_files_only: true
+  device: cuda:0
+  torch_dtype: bfloat16
+  use_flash_attn: true
+  frame_image_size: 448
+  max_new_tokens: 64
+  do_sample: false
+  temperature: 0.0
+  top_p: 0.9
+  trust_remote_code: true
+  verbose: false
+  load_in_8bit: false
+  load_in_4bit: false
+
+fusion:
+  fast_weight: 0.5
+  vlm_weight: 0.5
+  only_when_vlm_called: true
+  suppression_bound:
+    enabled: true
+    max_drop: 0.12
+    protect_above_score: 0.42
+    protect_floor_score: 0.36
+
+thresholds:
+  start_score: 0.47
+  end_score: 0.42
+  min_event_duration_sec: 0.5
+  split:
+    enabled: true
+    score_threshold: 0.33
+    min_consecutive_clips: 2
+  score_smoothing:
+    enabled: true
+    window_size: 3
+    method: moving_average
+
+outputs:
+  save_clip_manifest: true
+  save_frame_samples: false

--- a/AI/slowfast/configs/eval_event_overlap051_e20_fastonly.yaml
+++ b/AI/slowfast/configs/eval_event_overlap051_e20_fastonly.yaml
@@ -1,0 +1,70 @@
+project:
+  output_root: /home/deepgu/slowfast/outputs/eval/event_compare/overlap051_e20_fastonly
+
+clip:
+  temporal_window_sec: 2.0
+  stride_sec: 1.0
+  sampled_frames: 13
+  resize:
+    width: 160
+    height: 160
+  sampling: uniform
+
+fast_model:
+  device: auto
+  architecture: x3d_s
+  checkpoint_path: /home/deepgu/slowfast/outputs/train/overlap051_e20/x3d_s_fast_model_best.pt
+  num_classes: 1
+  input_clip_length: 13
+  input_crop_size: 160
+  batch_size: 8
+  use_pretrained_backbone: false
+  fallback_mode: heuristic
+  amp: true
+  use_pos_weight: true
+
+data_loader:
+  num_workers: 8
+  pin_memory: true
+  persistent_workers: true
+
+router:
+  prob_low: 0.40
+  prob_high: 0.60
+  uncertainty_threshold: 0.25
+  topk_ratio: 0.15
+  use_topk: false
+  alpha_entropy: 0.7
+  alpha_variance: 0.3
+  variance_window: 5
+
+vlm:
+  provider: internvl
+  enabled: false
+
+fusion:
+  fast_weight: 0.5
+  vlm_weight: 0.5
+  only_when_vlm_called: true
+  suppression_bound:
+    enabled: true
+    max_drop: 0.12
+    protect_above_score: 0.42
+    protect_floor_score: 0.36
+
+thresholds:
+  start_score: 0.47
+  end_score: 0.42
+  min_event_duration_sec: 0.5
+  split:
+    enabled: true
+    score_threshold: 0.33
+    min_consecutive_clips: 2
+  score_smoothing:
+    enabled: true
+    window_size: 3
+    method: moving_average
+
+outputs:
+  save_clip_manifest: true
+  save_frame_samples: false

--- a/AI/slowfast/configs/overlap051.yaml
+++ b/AI/slowfast/configs/overlap051.yaml
@@ -1,0 +1,107 @@
+project:
+  output_root: /home/deepgu/slowfast/outputs/runs
+
+clip:
+  temporal_window_sec: 2.0
+  stride_sec: 1.0
+  sampled_frames: 13
+  resize:
+    width: 160
+    height: 160
+  sampling: uniform
+
+fast_model:
+  device: auto
+  architecture: x3d_s
+  checkpoint_path: /home/deepgu/slowfast/models/fast/checkpoints/early_stop_pr_auc/x3d_s_fast_model_best.pt
+  num_classes: 1
+  input_clip_length: 13
+  input_crop_size: 160
+  batch_size: 8
+  use_pretrained_backbone: false
+  fallback_mode: heuristic
+  amp: true
+  use_pos_weight: true
+
+data_loader:
+  num_workers: 8
+  pin_memory: true
+  persistent_workers: true
+
+train:
+  train_csv: /home/deepgu/slowfast/data/manifests/cctv_x3d_s_overlap051/training_clips.csv
+  val_csv: /home/deepgu/slowfast/data/manifests/cctv_x3d_s_overlap051/validation_clips.csv
+
+loss:
+  type: bce
+  gamma: 2.0
+  alpha: null
+
+early_stopping:
+  enabled: true
+  monitor: pr_auc
+  patience: 2
+  min_delta: 0.0005
+
+sampler:
+  enabled: false
+  weights_csv: null
+  default_weight: 1.0
+
+router:
+  prob_low: 0.40
+  prob_high: 0.60
+  uncertainty_threshold: 0.25
+  topk_ratio: 0.15
+  use_topk: false
+  alpha_entropy: 0.7
+  alpha_variance: 0.3
+  variance_window: 5
+
+vlm:
+  provider: internvl
+  sampled_frames: 6
+  prompt_style: binary_fight
+  enabled: true
+  repo_path: /home/deepgu/VERA/InternVL/internvl_chat
+  model_path: /home/deepgu/.cache/huggingface/hub/models--OpenGVLab--InternVL2-8B/snapshots/6fb9ad6924f69424e57fab2ab061d707688f0296
+  local_files_only: true
+  device: cuda:0
+  torch_dtype: bfloat16
+  use_flash_attn: true
+  frame_image_size: 448
+  max_new_tokens: 64
+  do_sample: false
+  temperature: 0.0
+  top_p: 0.9
+  trust_remote_code: true
+  verbose: false
+  load_in_8bit: false
+  load_in_4bit: false
+
+fusion:
+  fast_weight: 0.5
+  vlm_weight: 0.5
+  only_when_vlm_called: true
+  suppression_bound:
+    enabled: true
+    max_drop: 0.12
+    protect_above_score: 0.42
+    protect_floor_score: 0.36
+
+thresholds:
+  start_score: 0.47
+  end_score: 0.42
+  min_event_duration_sec: 0.5
+  split:
+    enabled: true
+    score_threshold: 0.33
+    min_consecutive_clips: 2
+  score_smoothing:
+    enabled: true
+    window_size: 3
+    method: moving_average
+
+outputs:
+  save_clip_manifest: true
+  save_frame_samples: false

--- a/AI/slowfast/configs/train_overlap051.yaml
+++ b/AI/slowfast/configs/train_overlap051.yaml
@@ -1,0 +1,47 @@
+project:
+  output_root: /home/deepgu/slowfast/outputs/train
+
+clip:
+  temporal_window_sec: 2.0
+  stride_sec: 1.0
+  sampled_frames: 13
+  resize:
+    width: 160
+    height: 160
+  sampling: uniform
+
+fast_model:
+  device: auto
+  architecture: x3d_s
+  num_classes: 1
+  input_clip_length: 13
+  input_crop_size: 160
+  batch_size: 8
+  use_pretrained_backbone: false
+  amp: true
+  use_pos_weight: true
+
+data_loader:
+  num_workers: 8
+  pin_memory: true
+  persistent_workers: true
+
+train:
+  train_csv: /home/deepgu/slowfast/data/manifests/cctv_x3d_s_overlap051/training_clips.csv
+  val_csv: /home/deepgu/slowfast/data/manifests/cctv_x3d_s_overlap051/validation_clips.csv
+
+loss:
+  type: bce
+  gamma: 2.0
+  alpha: null
+
+early_stopping:
+  enabled: true
+  monitor: pr_auc
+  patience: 5
+  min_delta: 0.0005
+
+sampler:
+  enabled: false
+  weights_csv: null
+  default_weight: 1.0

--- a/AI/slowfast/configs/tuning_tmp/nova_pro_suppress_only.yaml
+++ b/AI/slowfast/configs/tuning_tmp/nova_pro_suppress_only.yaml
@@ -1,0 +1,73 @@
+project:
+  output_root: /home/deepgu/slowfast/outputs/eval/event_compare/nova_pro_suppress_only
+
+clip:
+  temporal_window_sec: 2.0
+  stride_sec: 1.0
+  sampled_frames: 13
+  resize:
+    width: 160
+    height: 160
+  sampling: uniform
+
+fast_model:
+  device: auto
+  architecture: x3d_s
+  checkpoint_path: /home/deepgu/slowfast/outputs/train/overlap051_e20/x3d_s_fast_model_best.pt
+  num_classes: 1
+  input_clip_length: 13
+  input_crop_size: 160
+  batch_size: 8
+  use_pretrained_backbone: false
+  fallback_mode: heuristic
+  amp: true
+  use_pos_weight: true
+
+data_loader:
+  num_workers: 8
+  pin_memory: true
+  persistent_workers: true
+
+router:
+  prob_low: 0.30
+  prob_high: 0.55
+  uncertainty_threshold: 0.0
+  topk_ratio: 0.15
+  use_topk: false
+  alpha_entropy: 0.7
+  alpha_variance: 0.3
+  variance_window: 5
+
+vlm:
+  provider: bedrock
+  sampled_frames: 6
+  prompt_style: binary_fight
+  enabled: true
+  model_id: amazon.nova-pro-v1:0
+  region: us-east-1
+  max_tokens: 256
+
+fusion:
+  fast_weight: 0.5
+  vlm_weight: 0.5
+  suppress_only: true
+  only_when_vlm_called: true
+  suppression_bound:
+    enabled: false
+
+thresholds:
+  start_score: 0.47
+  end_score: 0.42
+  min_event_duration_sec: 0.5
+  split:
+    enabled: true
+    score_threshold: 0.33
+    min_consecutive_clips: 2
+  score_smoothing:
+    enabled: true
+    window_size: 3
+    method: moving_average
+
+outputs:
+  save_clip_manifest: false
+  save_frame_samples: false

--- a/AI/slowfast/data/manifests/cctv_x3d_s_overlap051/summary.json
+++ b/AI/slowfast/data/manifests/cctv_x3d_s_overlap051/summary.json
@@ -1,0 +1,41 @@
+{
+  "source_filter": "CCTV",
+  "temporal_window_sec": 2.0,
+  "stride_sec": 1.0,
+  "positive_threshold": 0.5,
+  "negative_threshold": 0.1,
+  "videos_by_split": {
+    "validation": 70,
+    "testing": 70,
+    "training": 140
+  },
+  "candidate_clips_by_split": {
+    "validation": 7550,
+    "testing": 7201,
+    "training": 15617
+  },
+  "clips_by_split": {
+    "training": 15071,
+    "validation": 7264,
+    "testing": 6901
+  },
+  "labels_by_split": {
+    "training": {
+      "0": 10541,
+      "1": 4530
+    },
+    "validation": {
+      "0": 5102,
+      "1": 2162
+    },
+    "testing": {
+      "0": 5019,
+      "1": 1882
+    }
+  },
+  "discarded_ambiguous_clips_by_split": {
+    "training": 546,
+    "validation": 286,
+    "testing": 300
+  }
+}

--- a/AI/slowfast/pipeline/fusion.py
+++ b/AI/slowfast/pipeline/fusion.py
@@ -2,6 +2,7 @@ def fuse_scores(scored_clips, vlm_outputs, fusion_config):
     fast_weight = float(fusion_config.get("fast_weight", 0.5))
     vlm_weight = float(fusion_config.get("vlm_weight", 0.5))
     only_when_called = bool(fusion_config.get("only_when_vlm_called", True))
+    suppress_only = bool(fusion_config.get("suppress_only", False))
     suppression_cfg = fusion_config.get("suppression_bound", {})
     suppression_enabled = bool(suppression_cfg.get("enabled", False))
     max_drop = float(suppression_cfg.get("max_drop", 0.08))
@@ -19,12 +20,16 @@ def fuse_scores(scored_clips, vlm_outputs, fusion_config):
         if clip_id in vlm_outputs:
             vlm_score = float(vlm_outputs[clip_id]["score"])
             weighted_score = (fast_weight * fast_score) + (vlm_weight * vlm_score)
-            final_score = weighted_score
-            if suppression_enabled and weighted_score < fast_score:
+            if suppress_only:
+                # Never raise score above fast_score; only allow suppression
+                final_score = min(fast_score, weighted_score)
+            else:
+                final_score = weighted_score
+            if suppression_enabled and final_score < fast_score:
                 bounded_floor = fast_score - max_drop
                 if protect_above is not None and protect_floor is not None and fast_score >= protect_above:
                     bounded_floor = max(bounded_floor, protect_floor)
-                final_score = max(weighted_score, bounded_floor)
+                final_score = max(final_score, bounded_floor)
             cloned["vlm_called"] = True
             cloned["vlm_score"] = vlm_score
             cloned["weighted_score"] = float(weighted_score)

--- a/AI/slowfast/scripts/analyze_clip_score_distribution.py
+++ b/AI/slowfast/scripts/analyze_clip_score_distribution.py
@@ -1,0 +1,169 @@
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+
+
+def load_json(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_csv_rows(path):
+    with open(path, "r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def safe_float(value, default=None):
+    if value is None or value == "":
+        return default
+    return float(value)
+
+
+def quantile(sorted_values, q):
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+    pos = (len(sorted_values) - 1) * q
+    low = int(math.floor(pos))
+    high = int(math.ceil(pos))
+    if low == high:
+        return float(sorted_values[low])
+    frac = pos - low
+    return float(sorted_values[low] * (1.0 - frac) + sorted_values[high] * frac)
+
+
+def summarize(values):
+    if not values:
+        return {"count": 0}
+    values = [float(v) for v in values]
+    values_sorted = sorted(values)
+    mean = sum(values) / len(values)
+    var = sum((v - mean) ** 2 for v in values) / len(values)
+    return {
+        "count": len(values),
+        "mean": mean,
+        "std": math.sqrt(var),
+        "min": values_sorted[0],
+        "p10": quantile(values_sorted, 0.10),
+        "p25": quantile(values_sorted, 0.25),
+        "p50": quantile(values_sorted, 0.50),
+        "p75": quantile(values_sorted, 0.75),
+        "p90": quantile(values_sorted, 0.90),
+        "p95": quantile(values_sorted, 0.95),
+        "max": values_sorted[-1],
+    }
+
+
+def interval_overlap(a_start, a_end, b_start, b_end):
+    return max(0.0, min(a_end, b_end) - max(a_start, b_start))
+
+
+def tag_clips_by_intervals(clips, interval_rows, start_key, end_key):
+    tagged = set()
+    for row in interval_rows:
+        video_id = row["video_id"]
+        interval_start = safe_float(row[start_key])
+        interval_end = safe_float(row[end_key])
+        if interval_start is None or interval_end is None:
+            continue
+        for clip_id, clip in clips.items():
+            if clip["video_id"] != video_id:
+                continue
+            if interval_overlap(clip["start_time"], clip["end_time"], interval_start, interval_end) > 0.0:
+                tagged.add(clip_id)
+    return tagged
+
+
+def build_payload(rows, group_ids):
+    probs = [rows[clip_id]["fighting_prob"] for clip_id in group_ids]
+    entropies = [rows[clip_id]["entropy"] for clip_id in group_ids]
+    return {
+        "prob_summary": summarize(probs),
+        "entropy_summary": summarize(entropies),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--score-json", required=True)
+    parser.add_argument("--manifest-csv", required=True)
+    parser.add_argument("--missed-gt-csv", required=True)
+    parser.add_argument("--matched-gt-csv", required=True)
+    parser.add_argument("--false-positive-csv", required=True)
+    parser.add_argument("--output-json", required=True)
+    args = parser.parse_args()
+
+    score_payload = load_json(args.score_json)
+    manifest_rows = load_csv_rows(args.manifest_csv)
+    missed_rows = load_csv_rows(args.missed_gt_csv)
+    matched_rows = load_csv_rows(args.matched_gt_csv)
+    fp_rows = load_csv_rows(args.false_positive_csv)
+
+    score_rows = {}
+    for row in score_payload["rows"]:
+        score_rows[row["clip_id"]] = {
+            "clip_id": row["clip_id"],
+            "video_id": row["video_id"],
+            "label": int(row["label"]),
+            "fighting_prob": float(row["fighting_prob"]),
+            "entropy": float(row["entropy"]),
+        }
+
+    clips = {}
+    for row in manifest_rows:
+        clip_id = row["clip_id"]
+        if clip_id not in score_rows:
+            continue
+        clips[clip_id] = {
+            "clip_id": clip_id,
+            "video_id": row["video_id"],
+            "start_time": float(row["start_time"]),
+            "end_time": float(row["end_time"]),
+            "label": int(row["label"]),
+        }
+
+    positive_ids = {clip_id for clip_id, row in score_rows.items() if row["label"] == 1}
+    negative_ids = {clip_id for clip_id, row in score_rows.items() if row["label"] == 0}
+
+    missed_gt_clip_ids = tag_clips_by_intervals(clips, missed_rows, "gt_start", "gt_end")
+    matched_gt_clip_ids = tag_clips_by_intervals(clips, matched_rows, "gt_start", "gt_end")
+    fp_event_clip_ids = tag_clips_by_intervals(clips, fp_rows, "pred_start", "pred_end")
+
+    groups = {
+        "all_positive": positive_ids,
+        "all_negative": negative_ids,
+        "missed_gt_overlap_clips": missed_gt_clip_ids,
+        "matched_gt_overlap_clips": matched_gt_clip_ids,
+        "false_positive_event_overlap_clips": fp_event_clip_ids,
+        "missed_positive_clips": missed_gt_clip_ids & positive_ids,
+        "matched_positive_clips": matched_gt_clip_ids & positive_ids,
+        "fp_negative_clips": fp_event_clip_ids & negative_ids,
+        "fp_positive_clips": fp_event_clip_ids & positive_ids,
+    }
+
+    payload = {
+        "score_json": args.score_json,
+        "manifest_csv": args.manifest_csv,
+        "missed_gt_csv": args.missed_gt_csv,
+        "matched_gt_csv": args.matched_gt_csv,
+        "false_positive_csv": args.false_positive_csv,
+        "groups": {
+            group_name: build_payload(score_rows, clip_ids)
+            for group_name, clip_ids in groups.items()
+        },
+    }
+
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+
+    for group_name, group_payload in payload["groups"].items():
+        print(group_name, json.dumps(group_payload["prob_summary"], ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/AI/slowfast/scripts/analyze_overlap_labeling.py
+++ b/AI/slowfast/scripts/analyze_overlap_labeling.py
@@ -1,0 +1,293 @@
+import argparse
+import json
+import math
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils.io import ensure_dir, write_json
+
+
+BUCKETS = [
+    (0.0, 0.1),
+    (0.1, 0.2),
+    (0.2, 0.3),
+    (0.3, 0.4),
+    (0.4, 0.5),
+    (0.5, 0.6),
+    (0.6, 0.7),
+    (0.7, 0.8),
+    (0.8, 0.9),
+    (0.9, 1.01),
+]
+
+EVENT_LENGTH_BUCKETS = [
+    (0.0, 1.0, "lt_1s"),
+    (1.0, 2.0, "1_to_2s"),
+    (2.0, 4.0, "2_to_4s"),
+    (4.0, 8.0, "4_to_8s"),
+    (8.0, float("inf"), "ge_8s"),
+]
+
+
+def interval_overlap(a_start, a_end, b_start, b_end):
+    left = max(float(a_start), float(b_start))
+    right = min(float(a_end), float(b_end))
+    return max(0.0, right - left)
+
+
+def build_video_path(dataset_root, source, subset, video_id):
+    if source == "CCTV":
+        return Path(dataset_root) / "CCTV_DATA" / subset / f"{video_id}.mpeg"
+    return Path(dataset_root) / "NON_CCTV_DATA" / subset / f"{video_id}.mpeg"
+
+
+def count_candidate_clips(duration, temporal_window_sec, stride_sec):
+    if duration < temporal_window_sec:
+        return 0
+    max_clip_start = max(0.0, float(duration) - float(temporal_window_sec))
+    return int(math.floor(max_clip_start / float(stride_sec) + 1e-9)) + 1
+
+
+def assign_bucket(max_overlap_ratio, positive_threshold, negative_threshold):
+    if max_overlap_ratio >= float(positive_threshold):
+        return "positive"
+    if max_overlap_ratio <= float(negative_threshold):
+        return "negative"
+    return "discard"
+
+
+def find_overlap_bin(value):
+    for start, end in BUCKETS:
+        if value < end or (end > 1.0 and value <= 1.0):
+            return f"{start:.1f}_{min(end, 1.0):.1f}"
+    return "unknown"
+
+
+def find_event_length_bucket(length_sec):
+    for start, end, label in EVENT_LENGTH_BUCKETS:
+        if start <= length_sec < end:
+            return label
+    return "unknown"
+
+
+def analyze(
+    ground_truth_path,
+    dataset_root,
+    source_filter,
+    temporal_window_sec,
+    stride_sec,
+    positive_threshold,
+    negative_threshold,
+):
+    payload = json.load(open(ground_truth_path, "r", encoding="utf-8"))
+    database = payload["database"]
+
+    clip_rows = []
+    split_counts = defaultdict(Counter)
+    discard_overlap_hist = defaultdict(Counter)
+    event_bucket_stats = defaultdict(lambda: defaultdict(Counter))
+    event_coverage = defaultdict(Counter)
+
+    for video_id, meta in sorted(database.items()):
+        source = meta.get("source")
+        subset = meta.get("subset")
+        if source_filter and source != source_filter:
+            continue
+        if subset not in {"training", "validation", "testing"}:
+            continue
+
+        video_path = build_video_path(dataset_root, source, subset, video_id)
+        if not video_path.exists():
+            continue
+
+        duration = float(meta["duration"])
+        if duration < temporal_window_sec:
+            continue
+
+        fps = float(meta["frame_rate"])
+        nb_frames = int(meta["nb_frames"])
+        annotations = meta.get("annotations", [])
+        event_hits = [0] * len(annotations)
+
+        split_counts[subset]["videos"] += 1
+        split_counts[subset]["candidate_clips"] += count_candidate_clips(duration, temporal_window_sec, stride_sec)
+
+        clip_index = 0
+        max_clip_start = max(0.0, duration - float(temporal_window_sec))
+        clip_start_sec = 0.0
+        while clip_start_sec <= max_clip_start + 1e-9:
+            clip_end_sec = clip_start_sec + float(temporal_window_sec)
+            max_overlap_ratio = 0.0
+            best_event_index = None
+
+            for event_index, annotation in enumerate(annotations):
+                pos_start_sec, pos_end_sec = annotation["segment"]
+                overlap_sec = interval_overlap(clip_start_sec, clip_end_sec, pos_start_sec, pos_end_sec)
+                window_overlap_ratio = overlap_sec / float(temporal_window_sec)
+                if window_overlap_ratio > max_overlap_ratio:
+                    max_overlap_ratio = window_overlap_ratio
+                    best_event_index = event_index
+
+            bucket = assign_bucket(max_overlap_ratio, positive_threshold, negative_threshold)
+            split_counts[subset][bucket] += 1
+            if bucket == "discard":
+                discard_overlap_hist[subset][find_overlap_bin(max_overlap_ratio)] += 1
+            if bucket == "positive" and best_event_index is not None:
+                event_hits[best_event_index] += 1
+
+            clip_rows.append(
+                {
+                    "clip_id": f"{video_id}_{clip_index:04d}",
+                    "video_id": video_id,
+                    "split": subset,
+                    "source": source,
+                    "fps": fps,
+                    "nb_frames": nb_frames,
+                    "start_time": float(clip_start_sec),
+                    "end_time": float(clip_end_sec),
+                    "max_window_overlap_ratio": float(max_overlap_ratio),
+                    "assigned_bucket": bucket,
+                    "best_event_index": best_event_index,
+                }
+            )
+            clip_index += 1
+            clip_start_sec += float(stride_sec)
+
+        for event_index, annotation in enumerate(annotations):
+            start_sec, end_sec = annotation["segment"]
+            event_length_sec = max(0.0, float(end_sec) - float(start_sec))
+            length_bucket = find_event_length_bucket(event_length_sec)
+            event_bucket_stats[subset][length_bucket]["events"] += 1
+            event_bucket_stats[subset][length_bucket]["positive_clips"] += int(event_hits[event_index])
+            covered = int(event_hits[event_index] > 0)
+            event_bucket_stats[subset][length_bucket]["covered_events"] += covered
+            event_bucket_stats[subset][length_bucket]["uncovered_events"] += int(not covered)
+            event_coverage[subset]["events"] += 1
+            event_coverage[subset]["covered_events"] += covered
+            event_coverage[subset]["uncovered_events"] += int(not covered)
+
+    split_summary_rows = []
+    for subset, counter in sorted(split_counts.items()):
+        candidate = int(counter.get("candidate_clips", 0))
+        positive = int(counter.get("positive", 0))
+        negative = int(counter.get("negative", 0))
+        discard = int(counter.get("discard", 0))
+        usable = positive + negative
+        split_summary_rows.append(
+            {
+                "split": subset,
+                "videos": int(counter.get("videos", 0)),
+                "candidate_clips": candidate,
+                "positive": positive,
+                "negative": negative,
+                "discard": discard,
+                "usable": usable,
+                "positive_ratio": (positive / candidate) if candidate else 0.0,
+                "negative_ratio": (negative / candidate) if candidate else 0.0,
+                "discard_ratio": (discard / candidate) if candidate else 0.0,
+            }
+        )
+
+    discard_rows = []
+    for subset, counter in sorted(discard_overlap_hist.items()):
+        total = sum(counter.values())
+        for overlap_bin, count in sorted(counter.items()):
+            discard_rows.append(
+                {
+                    "split": subset,
+                    "overlap_bin": overlap_bin,
+                    "count": int(count),
+                    "ratio_within_discard": (count / total) if total else 0.0,
+                }
+            )
+
+    event_length_rows = []
+    for subset, bucket_map in sorted(event_bucket_stats.items()):
+        for length_bucket, counter in sorted(bucket_map.items()):
+            events = int(counter.get("events", 0))
+            event_length_rows.append(
+                {
+                    "split": subset,
+                    "event_length_bucket": length_bucket,
+                    "events": events,
+                    "covered_events": int(counter.get("covered_events", 0)),
+                    "uncovered_events": int(counter.get("uncovered_events", 0)),
+                    "positive_clips": int(counter.get("positive_clips", 0)),
+                    "coverage_ratio": (counter.get("covered_events", 0) / events) if events else 0.0,
+                    "avg_positive_clips_per_event": (counter.get("positive_clips", 0) / events) if events else 0.0,
+                }
+            )
+
+    coverage_rows = []
+    for subset, counter in sorted(event_coverage.items()):
+        events = int(counter.get("events", 0))
+        coverage_rows.append(
+            {
+                "split": subset,
+                "events": events,
+                "covered_events": int(counter.get("covered_events", 0)),
+                "uncovered_events": int(counter.get("uncovered_events", 0)),
+                "coverage_ratio": (counter.get("covered_events", 0) / events) if events else 0.0,
+            }
+        )
+
+    return {
+        "clip_rows": clip_rows,
+        "split_summary_rows": split_summary_rows,
+        "discard_rows": discard_rows,
+        "event_length_rows": event_length_rows,
+        "coverage_rows": coverage_rows,
+        "summary": {
+            "source_filter": source_filter,
+            "temporal_window_sec": float(temporal_window_sec),
+            "stride_sec": float(stride_sec),
+            "positive_threshold": float(positive_threshold),
+            "negative_threshold": float(negative_threshold),
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ground-truth-json", default="/home/deepgu/test/cctv/dataset/ground-truth.json")
+    parser.add_argument("--dataset-root", default="/home/deepgu/test/cctv/dataset")
+    parser.add_argument("--output-dir", default="/home/deepgu/slowfast/outputs/analysis/overlap051")
+    parser.add_argument("--source-filter", default="CCTV")
+    parser.add_argument("--temporal-window-sec", type=float, default=2.0)
+    parser.add_argument("--stride-sec", type=float, default=1.0)
+    parser.add_argument("--positive-threshold", type=float, default=0.5)
+    parser.add_argument("--negative-threshold", type=float, default=0.1)
+    args = parser.parse_args()
+
+    if float(args.negative_threshold) > float(args.positive_threshold):
+        raise ValueError("negative-threshold must be <= positive-threshold")
+
+    output_dir = ensure_dir(args.output_dir)
+    payload = analyze(
+        ground_truth_path=args.ground_truth_json,
+        dataset_root=args.dataset_root,
+        source_filter=args.source_filter,
+        temporal_window_sec=args.temporal_window_sec,
+        stride_sec=args.stride_sec,
+        positive_threshold=args.positive_threshold,
+        negative_threshold=args.negative_threshold,
+    )
+
+    pd.DataFrame(payload["clip_rows"]).to_csv(output_dir / "clip_overlap_analysis.csv", index=False)
+    pd.DataFrame(payload["split_summary_rows"]).to_csv(output_dir / "split_summary.csv", index=False)
+    pd.DataFrame(payload["discard_rows"]).to_csv(output_dir / "discard_overlap_hist.csv", index=False)
+    pd.DataFrame(payload["event_length_rows"]).to_csv(output_dir / "event_length_coverage.csv", index=False)
+    pd.DataFrame(payload["coverage_rows"]).to_csv(output_dir / "event_coverage_summary.csv", index=False)
+    write_json(output_dir / "summary.json", payload["summary"])
+    print(f"[analysis] output_dir={output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/AI/slowfast/scripts/build_cctv_manifests_overlap051.py
+++ b/AI/slowfast/scripts/build_cctv_manifests_overlap051.py
@@ -1,0 +1,215 @@
+import argparse
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils.io import ensure_dir, write_json
+
+
+def seconds_to_frame_range(start_sec, end_sec, fps, nb_frames):
+    start_frame = max(0, int(math.floor(float(start_sec) * float(fps))))
+    end_frame = min(int(nb_frames) - 1, int(math.ceil(float(end_sec) * float(fps))) - 1)
+    return start_frame, max(start_frame, end_frame)
+
+
+def interval_overlap(a_start, a_end, b_start, b_end):
+    left = max(float(a_start), float(b_start))
+    right = min(float(a_end), float(b_end))
+    return max(0.0, right - left)
+
+
+def build_video_path(dataset_root, source, subset, video_id):
+    if source == "CCTV":
+        return Path(dataset_root) / "CCTV_DATA" / subset / f"{video_id}.mpeg"
+    return Path(dataset_root) / "NON_CCTV_DATA" / subset / f"{video_id}.mpeg"
+
+
+def count_candidate_clips(duration, temporal_window_sec, stride_sec):
+    if duration < temporal_window_sec:
+        return 0
+    max_clip_start = max(0.0, float(duration) - float(temporal_window_sec))
+    return int(math.floor(max_clip_start / float(stride_sec) + 1e-9)) + 1
+
+
+def assign_label(max_overlap_ratio, positive_threshold, negative_threshold):
+    if max_overlap_ratio >= float(positive_threshold):
+        return 1
+    if max_overlap_ratio <= float(negative_threshold):
+        return 0
+    return None
+
+
+def make_clip_rows(
+    ground_truth_path,
+    dataset_root,
+    source_filter,
+    temporal_window_sec,
+    stride_sec,
+    positive_threshold,
+    negative_threshold,
+):
+    payload = json.load(open(ground_truth_path, "r", encoding="utf-8"))
+    database = payload["database"]
+
+    rows_by_split = {"training": [], "validation": [], "testing": []}
+    summary = {
+        "source_filter": source_filter,
+        "temporal_window_sec": float(temporal_window_sec),
+        "stride_sec": float(stride_sec),
+        "positive_threshold": float(positive_threshold),
+        "negative_threshold": float(negative_threshold),
+        "videos_by_split": Counter(),
+        "candidate_clips_by_split": Counter(),
+        "clips_by_split": Counter(),
+        "labels_by_split": {},
+        "discarded_ambiguous_clips_by_split": {},
+    }
+
+    for video_id, meta in sorted(database.items()):
+        source = meta.get("source")
+        subset = meta.get("subset")
+        if source_filter and source != source_filter:
+            continue
+        if subset not in rows_by_split:
+            continue
+
+        video_path = build_video_path(dataset_root, source, subset, video_id)
+        if not video_path.exists():
+            continue
+
+        fps = float(meta["frame_rate"])
+        nb_frames = int(meta["nb_frames"])
+        duration = float(meta["duration"])
+        if duration < temporal_window_sec:
+            continue
+
+        positive_ranges_sec = []
+        for annotation in meta.get("annotations", []):
+            start_sec, end_sec = annotation["segment"]
+            positive_ranges_sec.append((float(start_sec), float(end_sec)))
+
+        clip_index = 0
+        max_clip_start = max(0.0, duration - float(temporal_window_sec))
+        clip_start_sec = 0.0
+        while clip_start_sec <= max_clip_start + 1e-9:
+            clip_end_sec = clip_start_sec + float(temporal_window_sec)
+            start_frame, end_frame = seconds_to_frame_range(
+                clip_start_sec,
+                clip_end_sec,
+                fps,
+                nb_frames,
+            )
+            max_window_overlap_ratio = 0.0
+
+            for pos_start_sec, pos_end_sec in positive_ranges_sec:
+                overlap_sec = interval_overlap(clip_start_sec, clip_end_sec, pos_start_sec, pos_end_sec)
+                window_overlap_ratio = overlap_sec / float(temporal_window_sec)
+                if window_overlap_ratio > max_window_overlap_ratio:
+                    max_window_overlap_ratio = window_overlap_ratio
+
+            clip_label = assign_label(
+                max_overlap_ratio=max_window_overlap_ratio,
+                positive_threshold=positive_threshold,
+                negative_threshold=negative_threshold,
+            )
+            if clip_label is None:
+                clip_index += 1
+                clip_start_sec += float(stride_sec)
+                continue
+
+            rows_by_split[subset].append(
+                {
+                    "clip_id": f"{video_id}_{clip_index:04d}",
+                    "video_id": video_id,
+                    "video_path": str(video_path),
+                    "start_frame": int(start_frame),
+                    "end_frame": int(end_frame),
+                    "start_time": float(clip_start_sec),
+                    "end_time": float(clip_end_sec),
+                    "label": int(clip_label),
+                    "split": subset,
+                    "source": source,
+                    "hard_negative": 0,
+                    "max_window_overlap_ratio": float(max_window_overlap_ratio),
+                    "fps": fps,
+                    "nb_frames": nb_frames,
+                }
+            )
+            clip_index += 1
+            clip_start_sec += float(stride_sec)
+
+        summary["videos_by_split"][subset] += 1
+        summary["candidate_clips_by_split"][subset] += count_candidate_clips(
+            duration=duration,
+            temporal_window_sec=temporal_window_sec,
+            stride_sec=stride_sec,
+        )
+
+    for subset, rows in rows_by_split.items():
+        summary["clips_by_split"][subset] = len(rows)
+        label_counter = Counter(int(row["label"]) for row in rows)
+        summary["labels_by_split"][subset] = dict(label_counter)
+        summary["discarded_ambiguous_clips_by_split"][subset] = (
+            int(summary["candidate_clips_by_split"].get(subset, 0)) - len(rows)
+        )
+
+    summary["videos_by_split"] = dict(summary["videos_by_split"])
+    summary["candidate_clips_by_split"] = dict(summary["candidate_clips_by_split"])
+    summary["clips_by_split"] = dict(summary["clips_by_split"])
+    return rows_by_split, summary
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--ground-truth-json",
+        default="/home/deepgu/test/cctv/dataset/ground-truth.json",
+    )
+    parser.add_argument(
+        "--dataset-root",
+        default="/home/deepgu/test/cctv/dataset",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="/home/deepgu/slowfast/data/manifests/cctv_x3d_s_overlap051",
+    )
+    parser.add_argument("--source-filter", default="CCTV")
+    parser.add_argument("--temporal-window-sec", type=float, default=2.0)
+    parser.add_argument("--stride-sec", type=float, default=1.0)
+    parser.add_argument("--positive-threshold", type=float, default=0.5)
+    parser.add_argument("--negative-threshold", type=float, default=0.1)
+    args = parser.parse_args()
+
+    if float(args.negative_threshold) > float(args.positive_threshold):
+        raise ValueError("negative-threshold must be <= positive-threshold")
+
+    output_dir = ensure_dir(args.output_dir)
+    rows_by_split, summary = make_clip_rows(
+        ground_truth_path=args.ground_truth_json,
+        dataset_root=args.dataset_root,
+        source_filter=args.source_filter,
+        temporal_window_sec=args.temporal_window_sec,
+        stride_sec=args.stride_sec,
+        positive_threshold=args.positive_threshold,
+        negative_threshold=args.negative_threshold,
+    )
+
+    for subset, rows in rows_by_split.items():
+        csv_path = output_dir / f"{subset}_clips.csv"
+        pd.DataFrame(rows).to_csv(csv_path, index=False)
+        print(f"[manifest] subset={subset} rows={len(rows)} output={csv_path}")
+
+    write_json(output_dir / "summary.json", summary)
+    print(f"[summary] {summary}")
+
+
+if __name__ == "__main__":
+    main()

--- a/AI/slowfast/scripts/evaluate_event_batch.py
+++ b/AI/slowfast/scripts/evaluate_event_batch.py
@@ -1,0 +1,201 @@
+import argparse
+import math
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from pipeline.main_pipeline import run_single_video_pipeline
+from utils.config import load_config
+from utils.io import ensure_dir, load_json, write_json
+
+
+def build_video_path(dataset_root, source, subset, video_id):
+    if source == "CCTV":
+        return Path(dataset_root) / "CCTV_DATA" / subset / f"{video_id}.mpeg"
+    return Path(dataset_root) / "NON_CCTV_DATA" / subset / f"{video_id}.mpeg"
+
+
+def seconds_to_frame_range(start_sec, end_sec, fps, nb_frames):
+    start_frame = max(0, int(math.floor(float(start_sec) * float(fps))))
+    end_frame = min(int(nb_frames) - 1, int(math.ceil(float(end_sec) * float(fps))) - 1)
+    return start_frame, max(start_frame, end_frame)
+
+
+def interval_iou(a_start, a_end, b_start, b_end):
+    left = max(int(a_start), int(b_start))
+    right = min(int(a_end), int(b_end))
+    intersection = max(0, right - left + 1)
+    union = (int(a_end) - int(a_start) + 1) + (int(b_end) - int(b_start) + 1) - intersection
+    return intersection / union if union > 0 else 0.0
+
+
+def build_gt_events(meta):
+    fps = float(meta["frame_rate"])
+    nb_frames = int(meta["nb_frames"])
+    gt_events = []
+    for idx, annotation in enumerate(meta.get("annotations", [])):
+        start_sec, end_sec = annotation["segment"]
+        start_frame, end_frame = seconds_to_frame_range(start_sec, end_sec, fps, nb_frames)
+        gt_events.append(
+            {
+                "event_id": idx,
+                "label": str(annotation.get("label", "Fight")),
+                "start_frame": int(start_frame),
+                "end_frame": int(end_frame),
+                "start_time": float(start_sec),
+                "end_time": float(end_sec),
+                "duration_sec": max(0.0, float(end_sec) - float(start_sec)),
+            }
+        )
+    return gt_events
+
+
+def evaluate_video(pred_events, gt_events, iou_threshold):
+    matched = set()
+    true_positive = 0
+    matched_predicted_duration_sec = 0.0
+    for event in pred_events:
+        for index, gt in enumerate(gt_events):
+            if index in matched:
+                continue
+            iou = interval_iou(
+                event["start_frame"],
+                event["end_frame"],
+                gt["start_frame"],
+                gt["end_frame"],
+            )
+            if iou >= iou_threshold:
+                true_positive += 1
+                matched.add(index)
+                matched_predicted_duration_sec += float(event.get("duration_sec", 0.0))
+                break
+
+    false_positive = max(0, len(pred_events) - true_positive)
+    false_negative = max(0, len(gt_events) - true_positive)
+    precision = true_positive / max(1, true_positive + false_positive)
+    recall = true_positive / max(1, true_positive + false_negative)
+    f1 = 2 * precision * recall / max(precision + recall, 1e-12)
+    predicted_total_duration_sec = sum(float(event.get("duration_sec", 0.0)) for event in pred_events)
+    gt_total_duration_sec = sum(float(event.get("duration_sec", 0.0)) for event in gt_events)
+    return {
+        "true_positive": true_positive,
+        "false_positive": false_positive,
+        "false_negative": false_negative,
+        "event_precision": precision,
+        "event_recall": recall,
+        "event_f1": f1,
+        "predicted_event_count": len(pred_events),
+        "gt_event_count": len(gt_events),
+        "predicted_total_duration_sec": predicted_total_duration_sec,
+        "matched_predicted_duration_sec": matched_predicted_duration_sec,
+        "gt_total_duration_sec": gt_total_duration_sec,
+        "predicted_to_gt_duration_ratio": predicted_total_duration_sec / max(gt_total_duration_sec, 1e-12),
+    }
+
+
+def summarize(per_video):
+    tp = sum(int(item["true_positive"]) for item in per_video)
+    fp = sum(int(item["false_positive"]) for item in per_video)
+    fn = sum(int(item["false_negative"]) for item in per_video)
+    precision = tp / max(1, tp + fp)
+    recall = tp / max(1, tp + fn)
+    f1 = 2 * precision * recall / max(precision + recall, 1e-12)
+    predicted_total_duration_sec = sum(float(item["predicted_total_duration_sec"]) for item in per_video)
+    gt_total_duration_sec = sum(float(item["gt_total_duration_sec"]) for item in per_video)
+    return {
+        "video_count": len(per_video),
+        "true_positive": tp,
+        "false_positive": fp,
+        "false_negative": fn,
+        "event_precision": precision,
+        "event_recall": recall,
+        "event_f1": f1,
+        "fp_event_count": fp,
+        "fn_event_count": fn,
+        "predicted_total_duration_sec": predicted_total_duration_sec,
+        "gt_total_duration_sec": gt_total_duration_sec,
+        "predicted_to_gt_duration_ratio": predicted_total_duration_sec / max(gt_total_duration_sec, 1e-12),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--ground-truth-json", default="/home/deepgu/test/cctv/dataset/ground-truth.json")
+    parser.add_argument("--dataset-root", default="/home/deepgu/test/cctv/dataset")
+    parser.add_argument("--subset", default="testing")
+    parser.add_argument("--source-filter", default="CCTV")
+    parser.add_argument("--iou-threshold", type=float, default=0.1)
+    parser.add_argument("--run-prefix", default="event_eval")
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--summary-only", action="store_true")
+    parser.add_argument("--video-ids", nargs="+", default=None, help="평가할 video_id 목록 (미지정 시 전체)")
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    if args.summary_only:
+        outputs_config = config.setdefault("outputs", {})
+        outputs_config["save_run_artifacts"] = False
+        outputs_config["save_event_media"] = False
+        outputs_config["save_clip_manifest"] = False
+    database = load_json(args.ground_truth_json)["database"]
+    output_path = Path(args.output_json)
+    ensure_dir(output_path.parent)
+
+    per_video = []
+    processed = 0
+    for video_id, meta in sorted(database.items()):
+        source = meta.get("source")
+        subset = meta.get("subset")
+        if args.source_filter and source != args.source_filter:
+            continue
+        if subset != args.subset:
+            continue
+        if args.video_ids is not None and video_id not in args.video_ids:
+            continue
+
+        video_path = build_video_path(args.dataset_root, source, subset, video_id)
+        if not video_path.exists():
+            continue
+
+        run_name = f"{args.run_prefix}_{video_id}"
+        result = run_single_video_pipeline(str(video_path), deepcopy(config), run_name=run_name, verbose=False)
+        gt_events = build_gt_events(meta)
+        metrics = evaluate_video(result["events"], gt_events, iou_threshold=float(args.iou_threshold))
+        metrics["video_id"] = video_id
+        if result.get("output_dir") is not None:
+            metrics["output_dir"] = result["output_dir"]
+        per_video.append(metrics)
+        processed += 1
+        print(
+            f"[video] id={video_id} tp={metrics['true_positive']} fp={metrics['false_positive']} "
+            f"fn={metrics['false_negative']} recall={metrics['event_recall']:.4f} f1={metrics['event_f1']:.4f}",
+            flush=True,
+        )
+        if args.limit is not None and processed >= int(args.limit):
+            break
+
+    summary = summarize(per_video)
+    payload = {
+        "config": args.config,
+        "ground_truth_json": args.ground_truth_json,
+        "dataset_root": args.dataset_root,
+        "subset": args.subset,
+        "source_filter": args.source_filter,
+        "iou_threshold": float(args.iou_threshold),
+        "summary_only": bool(args.summary_only),
+        "summary": summary,
+        "per_video": per_video,
+    }
+    write_json(output_path, payload)
+    print(f"[summary] {summary}", flush=True)
+    print(f"[output] {output_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/AI/slowfast/scripts/inspect_validation_scores.py
+++ b/AI/slowfast/scripts/inspect_validation_scores.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 import torch
+from sklearn.metrics import average_precision_score, roc_auc_score
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -96,9 +97,17 @@ def main():
 
     positives = [row["fighting_prob"] for row in rows if row["label"] == 1]
     negatives = [row["fighting_prob"] for row in rows if row["label"] == 0]
+
+    all_labels = [row["label"] for row in rows]
+    all_probs = [row["fighting_prob"] for row in rows]
+    pr_auc = float(average_precision_score(all_labels, all_probs))
+    roc_auc = float(roc_auc_score(all_labels, all_probs))
+
     payload = {
         "checkpoint": str(checkpoint_path),
         "csv": args.csv,
+        "pr_auc": pr_auc,
+        "roc_auc": roc_auc,
         "positive_prob_summary": summarize(positives),
         "negative_prob_summary": summarize(negatives),
         "rows": rows,
@@ -108,6 +117,7 @@ def main():
     ensure_dir(output_path.parent)
     write_json(output_path, payload)
     print(f"[validation] output={output_path}")
+    print(f"[validation] pr_auc={pr_auc:.4f}  roc_auc={roc_auc:.4f}")
     print(f"[validation] positive={payload['positive_prob_summary']}")
     print(f"[validation] negative={payload['negative_prob_summary']}")
 

--- a/AI/slowfast/utils/video.py
+++ b/AI/slowfast/utils/video.py
@@ -1,7 +1,22 @@
 import math
+import os
+import subprocess
 from pathlib import Path
 
 import cv2
+
+
+# [수정] mp4v → H.264 변환 헬퍼: 브라우저 호환 H.264 mp4 생성
+def _transcode_to_h264(src: str, dst: str) -> bool:
+    try:
+        r = subprocess.run(
+            ["ffmpeg", "-y", "-i", src, "-c:v", "libx264", "-preset", "fast",
+             "-crf", "23", "-movflags", "+faststart", "-an", dst],
+            capture_output=True, timeout=120,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
 
 
 def normalize_video_fps(fps, default=30.0):
@@ -39,8 +54,11 @@ def save_video(frames, output_path, fps):
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     height, width = frames[0].shape[:2]
+
+    # [수정] mp4v로 먼저 쓰고 ffmpeg으로 H.264 변환 (브라우저 호환)
+    tmp_path = str(output_path) + ".tmp_mp4v.mp4"
     writer = cv2.VideoWriter(
-        str(output_path),
+        tmp_path,
         cv2.VideoWriter_fourcc(*"mp4v"),
         float(fps),
         (width, height),
@@ -50,6 +68,12 @@ def save_video(frames, output_path, fps):
             frame = cv2.resize(frame, (width, height), interpolation=cv2.INTER_LINEAR)
         writer.write(frame)
     writer.release()
+
+    if _transcode_to_h264(tmp_path, str(output_path)):
+        os.remove(tmp_path)
+    else:
+        import shutil
+        shutil.move(tmp_path, str(output_path))
 
 
 def clip_frame_span(clip_id, clip_length, stride):


### PR DESCRIPTION
## 🔍 Background

기존 `early_stop_pr_auc` 기반 fast scorer 구조 이후,
clip-level score distribution과 false positive 문제를 줄이기 위해
clean-label 기반 relabeling 및 fast model 재학습 진행함.

기존 clip labeling은

* `window_overlap_ratio >= 0.3`
* 또는 `gt_overlap_ratio >= 0.5`

이면 positive로 사용하는 방식이었음.

하지만 이 방식은

* event boundary
* weak motion
* ambiguity clip

까지 positive에 포함되는 경우가 많아,
모델이 애매한 clip에도 높은 confidence를 출력하는 문제가 존재했음.

이를 개선하기 위해

* `overlap >= 0.5 → positive`
* `overlap <= 0.1 → negative`
* `0.1 ~ 0.5 → discard`

방식으로 clean-label 기반 manifest를 다시 생성하고,
해당 dataset 기준으로 X3D fast model 재학습 진행함.

또한 기존 로컬 InternVL 기반 구조는

* GPU 메모리 점유가 큼
* 모델 교체 및 비교 실험이 어려움
* provider별 실험 비용이 큼

문제가 있어,
AWS Bedrock 기반 multimodal VLM provider 구조 추가함.

---

## 🎯 Main Changes

### overlap051 기반 relabeling 및 재학습

* overlap051 clean-label manifest 생성
* ambiguous boundary clip discard 적용
* overlap051 기반 X3D-S fast scorer 재학습
* validation PR-AUC 기반 best checkpoint 저장

### clip-level / event-level 평가 구조 추가

* clip-level score distribution 분석 스크립트 추가
* threshold sweep 기반 event-level 평가 추가
* fast-only event recall / FP 분석 구조 추가

### AWS Bedrock 기반 VLM provider 추가

* Bedrock runtime 기반 multimodal inference 연동
* Amazon Nova Pro / Claude Haiku / Qwen provider 실험 구조 추가
* provider abstraction 구조 정리

### suppress-only refinement 실험

* suppress-only fusion 로직 추가
* clip-level VLM refinement 실험 진행
* routing threshold 기반 refinement 구조 테스트

---

## 📊 Experiment Notes

* overlap051 scorer는 기존 baseline 대비 conservative score distribution 특성을 보임

* threshold 운영 구간에서 FP 감소 경향 확인

* suppress-only refinement 실험 과정에서

  * event fragmentation
  * FP split 증가
    문제가 일부 관찰됨

* 이후 weak/subtle violence recovery 한계가 확인되어,
  overlap030 + focal loss 기반 representation 개선 방향으로 후속 실험 진행 예정
