### PR TITLE
[Feat] high-score FP 분석 및 event-level VLM refinement 구조 재설계

### DIFF
--- a/AI/slowfast/configs/eval_event_overlap030_focal_internvl_event.yaml
+++ b/AI/slowfast/configs/eval_event_overlap030_focal_internvl_event.yaml
@@ -1,0 +1,86 @@
+project:
+  output_root: /home/deepgu/slowfast/outputs/eval/event_compare/overlap030_focal_internvl_event
+
+clip:
+  temporal_window_sec: 2.0
+  stride_sec: 1.0
+  sampled_frames: 13
+  resize:
+    width: 160
+    height: 160
+  sampling: uniform
+
+fast_model:
+  device: auto
+  architecture: x3d_s
+  checkpoint_path: /home/deepgu/slowfast/outputs/train/overlap030_focal/x3d_s_fast_model_best.pt
+  num_classes: 1
+  input_clip_length: 13
+  input_crop_size: 160
+  batch_size: 8
+  use_pretrained_backbone: false
+  fallback_mode: heuristic
+  amp: true
+  use_pos_weight: true
+
+data_loader:
+  num_workers: 8
+  pin_memory: true
+  persistent_workers: true
+
+vlm:
+  provider: internvl
+  enabled: true
+  level: event                  # clip(기존) vs event(신규)
+  sampled_frames_per_event: 8   # peak 주변 75% + 전체 25% 혼합 샘플링
+  peak_margin_sec: 4.0          # peak clip 기준 ±N초 구간에 집중
+  accept_threshold: 0.65        # >= 이 값 → accept
+  reject_threshold: 0.35        # <= 이 값 → reject
+  uncertain_action: keep        # accept/reject 사이 → keep (FN 방지)
+  peak_score_max: 0.85          # fast peak > 이 값 → VLM 없이 자동 accept
+  max_calls_per_video: 9999     # 사실상 무제한 (나중에 튜닝용)
+  # InternVL 설정 (기존과 동일)
+  repo_path: /home/deepgu/VERA/InternVL/internvl_chat
+  model_path: /home/deepgu/.cache/huggingface/hub/models--OpenGVLab--InternVL2-8B/snapshots/6fb9ad6924f69424e57fab2ab061d707688f0296
+  local_files_only: true
+  device: cuda:0
+  torch_dtype: bfloat16
+  use_flash_attn: false
+  frame_image_size: 448
+  max_new_tokens: 64
+  do_sample: false
+  temperature: 0.0
+  top_p: 0.9
+  trust_remote_code: true
+  verbose: false
+  load_in_8bit: false
+  load_in_4bit: false
+
+# router/fusion은 event-level에서 미사용.
+# fast-only event 생성에 필요한 fusion 기본값만 유지.
+fusion:
+  fast_weight: 1.0
+  vlm_weight: 0.0
+  only_when_vlm_called: true
+  suppression_bound:
+    enabled: false
+
+thresholds:
+  start_score: 0.47
+  end_score: 0.42
+  min_event_duration_sec: 0.5
+  split:
+    enabled: true
+    score_threshold: 0.33
+    min_consecutive_clips: 2
+  score_smoothing:
+    enabled: true
+    window_size: 3
+    method: moving_average
+
+outputs:
+  save_clip_manifest: false
+  save_run_artifacts: false
+  save_event_media: false
+  save_frame_samples: false
+# artifacts 임시 override는 별도 config 사용

--- a/AI/slowfast/configs/eval_event_overlap030_focal_internvl_event_artifacts.yaml
+++ b/AI/slowfast/configs/eval_event_overlap030_focal_internvl_event_artifacts.yaml
@@ -1,0 +1,84 @@
+project:
+  output_root: /home/deepgu/slowfast/outputs/eval/event_compare/overlap030_focal_internvl_event
+
+clip:
+  temporal_window_sec: 2.0
+  stride_sec: 1.0
+  sampled_frames: 13
+  resize:
+    width: 160
+    height: 160
+  sampling: uniform
+
+fast_model:
+  device: auto
+  architecture: x3d_s
+  checkpoint_path: /home/deepgu/slowfast/outputs/train/overlap030_focal/x3d_s_fast_model_best.pt
+  num_classes: 1
+  input_clip_length: 13
+  input_crop_size: 160
+  batch_size: 8
+  use_pretrained_backbone: false
+  fallback_mode: heuristic
+  amp: true
+  use_pos_weight: true
+
+data_loader:
+  num_workers: 8
+  pin_memory: true
+  persistent_workers: true
+
+vlm:
+  provider: internvl
+  enabled: true
+  level: event                  # clip(기존) vs event(신규)
+  sampled_frames_per_event: 8   # 이벤트 길이와 무관하게 균일 샘플링
+  accept_threshold: 0.65        # >= 이 값 → accept
+  reject_threshold: 0.35        # <= 이 값 → reject
+  uncertain_action: keep        # accept/reject 사이 → keep (FN 방지)
+  peak_score_max: 0.85          # fast peak > 이 값 → VLM 없이 자동 accept
+  max_calls_per_video: 9999     # 사실상 무제한 (나중에 튜닝용)
+  # InternVL 설정 (기존과 동일)
+  repo_path: /home/deepgu/VERA/InternVL/internvl_chat
+  model_path: /home/deepgu/.cache/huggingface/hub/models--OpenGVLab--InternVL2-8B/snapshots/6fb9ad6924f69424e57fab2ab061d707688f0296
+  local_files_only: true
+  device: cuda:0
+  torch_dtype: bfloat16
+  use_flash_attn: false
+  frame_image_size: 448
+  max_new_tokens: 64
+  do_sample: false
+  temperature: 0.0
+  top_p: 0.9
+  trust_remote_code: true
+  verbose: false
+  load_in_8bit: false
+  load_in_4bit: false
+
+# router/fusion은 event-level에서 미사용.
+# fast-only event 생성에 필요한 fusion 기본값만 유지.
+fusion:
+  fast_weight: 1.0
+  vlm_weight: 0.0
+  only_when_vlm_called: true
+  suppression_bound:
+    enabled: false
+
+thresholds:
+  start_score: 0.47
+  end_score: 0.42
+  min_event_duration_sec: 0.5
+  split:
+    enabled: true
+    score_threshold: 0.33
+    min_consecutive_clips: 2
+  score_smoothing:
+    enabled: true
+    window_size: 3
+    method: moving_average
+
+outputs:
+  save_clip_manifest: false
+  save_run_artifacts: true
+  save_event_media: false
+  save_frame_samples: false

--- a/AI/slowfast/models/vlm/infer.py
+++ b/AI/slowfast/models/vlm/infer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import importlib.util
 import sys
 from pathlib import Path
@@ -10,7 +11,7 @@ import cv2
 import numpy as np
 
 from models.vlm.parser import parse_vlm_response
-from models.vlm.prompts import build_binary_fight_prompt
+from models.vlm.prompts import build_binary_fight_prompt, build_event_fight_prompt
 
 
 class MockVLMProvider:
@@ -51,7 +52,7 @@ class InternVLVLMProvider:
         model = runtime["model"]
         tokenizer = runtime["tokenizer"]
 
-        sampled_frames = self._sample_frames(clip_record["frames"])
+        sampled_frames = _sample_frames(clip_record["frames"], self.sampled_frames)
         question = self._build_question(prompt, num_frames=len(sampled_frames))
         pixel_values, num_patches_list = self._build_pixel_values(sampled_frames, runtime)
         pixel_values = pixel_values.to(dtype=runtime["dtype"])
@@ -231,6 +232,71 @@ class InternVLVLMProvider:
         return pixel_values, num_patches_list
 
 
+def _sample_frames(frames: List[np.ndarray], count: int) -> List[np.ndarray]:
+    if not frames:
+        raise ValueError("cannot run VLM on an empty clip")
+    count = min(count, len(frames))
+    if count <= 1:
+        return [frames[0]]
+    last_index = len(frames) - 1
+    anchor_indices = [0, last_index // 2, last_index]
+    if count <= 3:
+        chosen = sorted(set(anchor_indices[:count]))
+    else:
+        extra_needed = count - len(set(anchor_indices))
+        extra_indices = np.linspace(0, last_index, num=extra_needed + 2)[1:-1]
+        chosen = sorted(set(anchor_indices + [int(round(i)) for i in extra_indices]))
+        if len(chosen) > count:
+            chosen = chosen[:count]
+        while len(chosen) < count:
+            for candidate in range(last_index + 1):
+                if candidate not in chosen:
+                    chosen.append(candidate)
+                if len(chosen) == count:
+                    break
+            chosen = sorted(chosen)
+    return [frames[i] for i in chosen]
+
+
+class BedrockVLMProvider:
+    def __init__(self, config):
+        self.model_id = str(config.get("model_id", "us.anthropic.claude-haiku-4-5-20251001-v1:0"))
+        self.region = str(config.get("region", "us-east-1"))
+        self.max_tokens = int(config.get("max_tokens", 256))
+        self.sampled_frames = int(config.get("sampled_frames", 6))
+        self._client = None
+
+    def _get_client(self):
+        if self._client is None:
+            import boto3
+            self._client = boto3.client("bedrock-runtime", region_name=self.region)
+        return self._client
+
+    def invoke(self, clip_record, prompt):
+        sampled = _sample_frames(clip_record["frames"], self.sampled_frames)
+
+        content = []
+        for frame in sampled:
+            rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            success, buf = cv2.imencode(".jpg", rgb, [cv2.IMWRITE_JPEG_QUALITY, 85])
+            if not success:
+                continue
+            content.append({
+                "image": {
+                    "format": "jpeg",
+                    "source": {"bytes": buf.tobytes()},
+                }
+            })
+        content.append({"text": prompt})
+
+        response = self._get_client().converse(
+            modelId=self.model_id,
+            messages=[{"role": "user", "content": content}],
+            inferenceConfig={"maxTokens": self.max_tokens, "temperature": 0.0},
+        )
+        return response["output"]["message"]["content"][0]["text"]
+
+
 class VLMRefiner:
     def __init__(self, config):
         self.provider_name = str(config.get("provider", "mock")).lower()
@@ -241,8 +307,33 @@ class VLMRefiner:
             self.provider = MockVLMProvider()
         elif self.provider_name == "internvl":
             self.provider = InternVLVLMProvider(config)
+        elif self.provider_name == "bedrock":
+            self.provider = BedrockVLMProvider(config)
         else:
             raise ValueError(f"unsupported VLM provider: {self.provider_name}")
+
+    def score_event(self, event_frames, event_meta=None):
+        """Score an entire event window as a single VLM call (event-level VLM)."""
+        meta = event_meta or {}
+        duration_sec = float(meta.get("duration_sec", 0.0))
+        prompt = build_event_fight_prompt(num_frames=len(event_frames), duration_sec=duration_sec)
+        event_record = {
+            "frames": event_frames,
+            "fighting_prob": float(meta.get("peak_score", 0.5)),
+            "uncertainty": 0.5,
+            "motion_summary": f"event duration {duration_sec:.1f}s",
+        }
+        raw = self.provider.invoke(event_record, prompt)
+        parsed = parse_vlm_response(raw)
+        label = parsed.get("label", "non_fight")
+        confidence = float(parsed.get("confidence", 0.5))
+        score = confidence if label == "fight" else 1.0 - confidence
+        return {
+            "prompt": prompt,
+            "raw_response": raw,
+            "parsed": parsed,
+            "score": max(0.0, min(1.0, score)),
+        }
 
     def score_clip(self, clip_record):
         prompt = build_binary_fight_prompt(

--- a/AI/slowfast/models/vlm/prompts.py
+++ b/AI/slowfast/models/vlm/prompts.py
@@ -1,3 +1,23 @@
+def build_event_fight_prompt(num_frames, duration_sec=None):
+    duration_note = f" spanning approximately {duration_sec:.1f} seconds" if duration_sec else ""
+    return (
+        f"You are given {int(num_frames)} frames sampled from a CCTV event{duration_note}.\n"
+        "An automated detector flagged this event as a potential physical fight.\n"
+        "Review the full sequence and decide: is this an actual fight or a false alarm?\n"
+        "Count as fight: visible striking, kicking, grabbing, forceful pushing, chasing to attack.\n"
+        "Count as non_fight: bystanders watching, someone helping an injured/fallen person, "
+        "argument or confrontation without physical contact, post-fight scene with no active violence "
+        "(e.g. person lying on ground being assisted, police restraining after the fact), "
+        "or normal crowd movement.\n"
+        "Focus on whether ACTIVE physical violence is happening, not its aftermath.\n"
+        "Return strict JSON only with keys: label, confidence, reasoning.\n"
+        'Use label="fight" or label="non_fight".\n'
+        "Use confidence as a float between 0.0 and 1.0.\n"
+        "Keep reasoning short, under 20 words.\n"
+        '"Does this event show active physical violence (not just its aftermath or crowd)?"'
+    )
+
+
 def build_binary_fight_prompt(motion_summary, num_frames=None):
     frame_note = ""
     if num_frames is not None:

--- a/AI/slowfast/pipeline/event_builder.py
+++ b/AI/slowfast/pipeline/event_builder.py
@@ -111,10 +111,14 @@ def build_events(scored_clips, thresholds, fps):
     end_score = float(thresholds["end_score"])
     min_event_duration_sec = float(thresholds.get("min_event_duration_sec", 0.0))
 
+    # clip_id → frame bounds 매핑 (peak clip 위치 추적용)
+    clip_bounds = {int(r["clip_id"]): (int(r["start_frame"]), int(r["end_frame"])) for r in ordered}
+
     events = []
     current = None
     for result in ordered:
         score = float(result["final_score"])
+        clip_id = int(result["clip_id"])
         if current is None:
             if score >= start_score:
                 current = {
@@ -122,18 +126,21 @@ def build_events(scored_clips, thresholds, fps):
                     "label": "fight",
                     "start_frame": int(result["start_frame"]),
                     "end_frame": int(result["end_frame"]),
-                    "clip_ids": [int(result["clip_id"])],
+                    "clip_ids": [clip_id],
                     "peak_score": score,
+                    "peak_clip_id": clip_id,
                     "confidence": score,
                 }
             continue
 
         previous_clip_id = current["clip_ids"][-1]
-        is_contiguous = int(result["clip_id"]) == previous_clip_id + 1
+        is_contiguous = clip_id == previous_clip_id + 1
         if score >= end_score and is_contiguous:
             current["end_frame"] = int(result["end_frame"])
-            current["clip_ids"].append(int(result["clip_id"]))
-            current["peak_score"] = max(current["peak_score"], score)
+            current["clip_ids"].append(clip_id)
+            if score > current["peak_score"]:
+                current["peak_score"] = score
+                current["peak_clip_id"] = clip_id
             current["confidence"] = current["peak_score"]
             continue
 
@@ -145,8 +152,9 @@ def build_events(scored_clips, thresholds, fps):
                 "label": "fight",
                 "start_frame": int(result["start_frame"]),
                 "end_frame": int(result["end_frame"]),
-                "clip_ids": [int(result["clip_id"])],
+                "clip_ids": [clip_id],
                 "peak_score": score,
+                "peak_clip_id": clip_id,
                 "confidence": score,
             }
 

--- a/AI/slowfast/pipeline/event_payload.py
+++ b/AI/slowfast/pipeline/event_payload.py
@@ -177,9 +177,9 @@ def _build_routing_info(config, event, score_by_clip):
     return {
         "selected_for_vlm": vlm_call_count > 0,
         "executed_vlm_calls": vlm_call_count,
-        "router_prob_low": float(config["router"].get("prob_low", 0.0)),
-        "router_prob_high": float(config["router"].get("prob_high", 1.0)),
-        "uncertainty_threshold": float(config["router"].get("uncertainty_threshold", 0.0)),
+        "router_prob_low": float(config.get("router", {}).get("prob_low", 0.0)),
+        "router_prob_high": float(config.get("router", {}).get("prob_high", 1.0)),
+        "uncertainty_threshold": float(config.get("router", {}).get("uncertainty_threshold", 0.0)),
     }
 
 

--- a/AI/slowfast/pipeline/event_vlm_filter.py
+++ b/AI/slowfast/pipeline/event_vlm_filter.py
@@ -1,0 +1,170 @@
+"""
+Event-level VLM filter.
+
+Fast model이 생성한 이벤트 후보를 VLM이 이벤트 단위로 검증.
+- clip-level fusion 없음: fast_peak_score 보존
+- 3단계 결정: accept / uncertain / reject
+- peak_score 상한(peak_score_max) 초과 이벤트는 VLM 없이 자동 accept
+"""
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+import numpy as np
+
+
+def extract_event_frames(
+    all_frames: list,
+    event: Dict[str, Any],
+    n_frames: int,
+    fps: float = 30.0,
+    peak_margin_sec: float = 4.0,
+) -> list:
+    """
+    Peak-biased frame sampling: peak_clip 주변 ±peak_margin_sec 구간에서
+    ceil(n_frames * 0.75)프레임, 나머지는 이벤트 전체 구간에서 균일 샘플링.
+    """
+    ev_start = max(0, int(event["start_frame"]))
+    ev_end = min(len(all_frames) - 1, int(event["end_frame"]))
+    if ev_start > ev_end:
+        return [all_frames[ev_start]] if ev_start < len(all_frames) else []
+
+    def _uniform(lo, hi, k):
+        lo, hi = max(0, lo), min(len(all_frames) - 1, hi)
+        if lo >= hi:
+            return [lo] * k
+        total = hi - lo + 1
+        if total <= k:
+            return list(range(lo, hi + 1))
+        return [lo + int(round(i * (total - 1) / (k - 1))) for i in range(k)]
+
+    # peak 클립 위치 파악
+    peak_clip_id = event.get("peak_clip_id")
+    margin_frames = int(peak_margin_sec * fps)
+
+    if peak_clip_id is not None:
+        # peak 클립의 프레임 범위를 이벤트 clip_ids로 역추산
+        # (clip_id는 0-based 인덱스, stride=fps 가정)
+        # clip의 start_frame = clip_id * stride_frames
+        # 하지만 정확한 값은 event의 start_frame + clip 위치로 추정
+        clip_ids = event.get("clip_ids", [])
+        if clip_ids:
+            peak_pos = clip_ids.index(peak_clip_id) if peak_clip_id in clip_ids else len(clip_ids) // 2
+            # 이벤트 내 clip 위치 비율로 peak frame 추정
+            ratio = peak_pos / max(len(clip_ids) - 1, 1)
+            peak_frame = ev_start + int(ratio * (ev_end - ev_start))
+        else:
+            peak_frame = (ev_start + ev_end) // 2
+
+        p_start = max(ev_start, peak_frame - margin_frames)
+        p_end = min(ev_end, peak_frame + margin_frames)
+
+        n_peak = max(1, int(np.ceil(n_frames * 0.75)))
+        n_full = n_frames - n_peak
+
+        peak_idx = _uniform(p_start, p_end, n_peak)
+        full_idx = _uniform(ev_start, ev_end, n_full) if n_full > 0 else []
+        indices = sorted(set(peak_idx + full_idx))
+        # 부족하면 peak 구간에서 추가
+        while len(indices) < n_frames:
+            extra = _uniform(p_start, p_end, n_frames - len(indices) + len(peak_idx))
+            indices = sorted(set(indices + extra))
+            if len(indices) >= n_frames:
+                break
+        indices = indices[:n_frames]
+    else:
+        # peak 정보 없으면 전체 균일
+        indices = _uniform(ev_start, ev_end, n_frames)
+
+    return [all_frames[i] for i in indices]
+
+
+def _decide(vlm_score: float, accept_thr: float, reject_thr: float) -> str:
+    if vlm_score >= accept_thr:
+        return "accept"
+    if vlm_score <= reject_thr:
+        return "reject"
+    return "uncertain"
+
+
+def filter_events_by_vlm(
+    events: List[Dict[str, Any]],
+    all_frames: list,
+    fps: float,
+    vlm_config: Dict[str, Any],
+) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]], int]:
+    """
+    Returns (kept_events, rejected_events, vlm_call_count).
+    각 이벤트에 fast_peak_score / vlm_score / vlm_decision / vlm_called 필드 추가.
+    """
+    from models.vlm.infer import VLMRefiner
+
+    accept_thr = float(vlm_config.get("accept_threshold", 0.65))
+    reject_thr = float(vlm_config.get("reject_threshold", 0.35))
+    uncertain_action = str(vlm_config.get("uncertain_action", "keep")).lower()
+    peak_score_max = float(vlm_config.get("peak_score_max", 0.85))
+    n_frames = int(vlm_config.get("sampled_frames_per_event", 8))
+    peak_margin_sec = float(vlm_config.get("peak_margin_sec", 4.0))
+    max_calls = int(vlm_config.get("max_calls_per_video", 9999))
+
+    refiner = VLMRefiner(vlm_config)
+    kept = []
+    rejected = []
+    vlm_call_count = 0
+
+    for event in events:
+        peak_score = float(event.get("peak_score", 0.0))
+        event["fast_peak_score"] = peak_score
+
+        # 매우 확실한 이벤트 → VLM 없이 통과
+        if peak_score > peak_score_max:
+            event["vlm_called"] = False
+            event["vlm_decision"] = "accept"
+            event["vlm_score"] = None
+            kept.append(event)
+            continue
+
+        # VLM 호출 한도 초과 → uncertain 처리
+        if vlm_call_count >= max_calls:
+            event["vlm_called"] = False
+            event["vlm_decision"] = "uncertain"
+            event["vlm_score"] = None
+            if uncertain_action != "discard":
+                kept.append(event)
+            else:
+                rejected.append(event)
+            continue
+
+        # 이벤트 프레임 추출 후 VLM 호출
+        event_frames = extract_event_frames(all_frames, event, n_frames, fps=fps,
+                                            peak_margin_sec=peak_margin_sec)
+        if not event_frames:
+            event["vlm_called"] = False
+            event["vlm_decision"] = "uncertain"
+            event["vlm_score"] = None
+            if uncertain_action != "discard":
+                kept.append(event)
+            else:
+                rejected.append(event)
+            continue
+
+        result = refiner.score_event(event_frames, event_meta=event)
+        vlm_call_count += 1
+
+        vlm_score = float(result["score"])
+        decision = _decide(vlm_score, accept_thr, reject_thr)
+
+        event["vlm_called"] = True
+        event["vlm_score"] = vlm_score
+        event["vlm_decision"] = decision
+        event["vlm_raw"] = result.get("raw_response", "")
+
+        if decision == "reject":
+            rejected.append(event)
+            continue
+        if decision == "uncertain" and uncertain_action == "discard":
+            rejected.append(event)
+            continue
+        kept.append(event)
+
+    return kept, rejected, vlm_call_count

--- a/AI/slowfast/pipeline/main_pipeline.py
+++ b/AI/slowfast/pipeline/main_pipeline.py
@@ -4,6 +4,7 @@ from models.vlm.infer import VLMRefiner
 from pipeline.clip_generator import build_sliding_clips
 from pipeline.event_payload import attach_event_media, build_event_payload_bundle
 from pipeline.event_builder import build_events
+from pipeline.event_vlm_filter import filter_events_by_vlm
 from pipeline.fast_stage import score_clips_fast
 from pipeline.fusion import fuse_scores
 from pipeline.motion_summary import attach_motion_summaries
@@ -19,7 +20,14 @@ def run_single_video_pipeline(video_path, config, run_name="single_video", verbo
     if not frames:
         raise ValueError(f"video has no frames: {video_path}")
 
-    output_root = ensure_dir(Path(config["project"]["output_root"]) / run_name)
+    outputs_config = config.get("outputs", {})
+    save_run_artifacts = bool(outputs_config.get("save_run_artifacts", True))
+    save_event_media = bool(outputs_config.get("save_event_media", True))
+    save_clip_manifest = bool(outputs_config.get("save_clip_manifest", True))
+
+    output_root = None
+    if save_run_artifacts:
+        output_root = ensure_dir(Path(config["project"]["output_root"]) / run_name)
     if verbose:
         print(f"[video] frames={len(frames)} fps={fps:.3f}")
 
@@ -33,29 +41,51 @@ def run_single_video_pipeline(video_path, config, run_name="single_video", verbo
         print(f"[clips] generated={len(clips)}")
 
     scored = score_clips_fast(clips, config["fast_model"], config["clip"])
+    router_cfg = config.get("router", {})
     scored = attach_uncertainty(
         scored,
         score_key="fighting_prob",
-        alpha_entropy=float(config["router"].get("alpha_entropy", 0.7)),
-        alpha_variance=float(config["router"].get("alpha_variance", 0.3)),
-        variance_window=int(config["router"].get("variance_window", 5)),
+        alpha_entropy=float(router_cfg.get("alpha_entropy", 0.7)),
+        alpha_variance=float(router_cfg.get("alpha_variance", 0.3)),
+        variance_window=int(router_cfg.get("variance_window", 5)),
     )
     scored = attach_motion_summaries(scored)
 
-    vlm_outputs = {}
-    selected_clip_ids = []
-    if config["vlm"].get("enabled", True):
-        selected_clip_ids = select_vlm_clips(scored, config["router"])
-        refiner = VLMRefiner(config["vlm"])
-        for item in scored:
-            if int(item["clip_id"]) not in selected_clip_ids:
-                continue
-            vlm_outputs[int(item["clip_id"])] = refiner.score_clip(item)
-    if verbose:
-        print(f"[vlm] selected={len(selected_clip_ids)}")
+    vlm_enabled = bool(config["vlm"].get("enabled", True))
+    vlm_level = str(config["vlm"].get("level", "clip")).lower()
 
-    fused = fuse_scores(scored, vlm_outputs, config["fusion"])
-    events, smoothed_scores = build_events(fused, config["thresholds"], fps=fps)
+    if vlm_enabled and vlm_level == "event":
+        # Event-level VLM: fast-only event detection → VLM judges each event
+        fused = fuse_scores(scored, {}, config["fusion"])
+        events, smoothed_scores = build_events(fused, config["thresholds"], fps=fps)
+        if verbose:
+            print(f"[events] candidates={len(events)}")
+        events, rejected_events, n_vlm_calls = filter_events_by_vlm(events, frames, fps, config["vlm"])
+        vlm_outputs = {}
+        if verbose:
+            decisions = {}
+            for e in events + rejected_events:
+                d = e.get("vlm_decision", "?")
+                decisions[d] = decisions.get(d, 0) + 1
+            print(f"[vlm] event-level calls={n_vlm_calls}, kept={len(events)}, "
+                  f"rejected={len(rejected_events)}, decisions={decisions}")
+    else:
+        # Clip-level VLM (original path)
+        vlm_outputs = {}
+        selected_clip_ids = []
+        if vlm_enabled:
+            selected_clip_ids = select_vlm_clips(scored, config["router"])
+            refiner = VLMRefiner(config["vlm"])
+            for item in scored:
+                if int(item["clip_id"]) not in selected_clip_ids:
+                    continue
+                vlm_outputs[int(item["clip_id"])] = refiner.score_clip(item)
+        if verbose:
+            print(f"[vlm] selected={len(selected_clip_ids)}")
+        fused = fuse_scores(scored, vlm_outputs, config["fusion"])
+        events, smoothed_scores = build_events(fused, config["thresholds"], fps=fps)
+        rejected_events = []
+
     if verbose:
         print(f"[events] generated={len(events)}")
 
@@ -81,34 +111,40 @@ def run_single_video_pipeline(video_path, config, run_name="single_video", verbo
         payload = {key: value for key, value in item.items() if key != "frames"}
         serializable_scores.append(payload)
 
-    write_json(output_root / "manifest.json", manifest)
-    write_json(output_root / "events.json", events)
-    write_json(output_root / "clip_scores.json", serializable_scores)
-    write_json(output_root / "vlm_outputs.json", vlm_outputs)
-    event_payload = build_event_payload_bundle(
-        manifest=manifest,
-        events=events,
-        clip_scores=serializable_scores,
-        vlm_outputs=vlm_outputs,
-        config=config,
-        run_name=run_name,
-        cctv_id=config.get("deployment", {}).get("cctv_id"),
-        stream_id=config.get("deployment", {}).get("stream_id"),
-        status="new",
-    )
-    event_payload = attach_event_media(
-        payload_bundle=event_payload,
-        frames=frames,
-        output_root=output_root,
-    )
-    write_json(output_root / "event_payload.json", event_payload)
-    if config["outputs"].get("save_clip_manifest", True):
-        write_json(output_root / "clip_manifest.json", clip_manifest)
+    event_payload = None
+    if save_run_artifacts:
+        write_json(output_root / "manifest.json", manifest)
+        write_json(output_root / "events.json", events)
+        write_json(output_root / "clip_scores.json", serializable_scores)
+        write_json(output_root / "vlm_outputs.json", vlm_outputs)
+        if rejected_events:
+            write_json(output_root / "rejected_events.json", rejected_events)
+        event_payload = build_event_payload_bundle(
+            manifest=manifest,
+            events=events,
+            clip_scores=serializable_scores,
+            vlm_outputs=vlm_outputs,
+            config=config,
+            run_name=run_name,
+            cctv_id=config.get("deployment", {}).get("cctv_id"),
+            stream_id=config.get("deployment", {}).get("stream_id"),
+            status="new",
+        )
+        if save_event_media:
+            event_payload = attach_event_media(
+                payload_bundle=event_payload,
+                frames=frames,
+                output_root=output_root,
+            )
+        write_json(output_root / "event_payload.json", event_payload)
+        if save_clip_manifest:
+            write_json(output_root / "clip_manifest.json", clip_manifest)
 
     return {
         "manifest": manifest,
         "events": events,
+        "rejected_events": rejected_events,
         "clip_scores": serializable_scores,
         "event_payload": event_payload,
-        "output_dir": str(output_root),
+        "output_dir": str(output_root) if output_root is not None else None,
     }

--- a/AI/slowfast/scripts/analyze_fast_only_failures.py
+++ b/AI/slowfast/scripts/analyze_fast_only_failures.py
@@ -1,0 +1,223 @@
+import argparse
+import csv
+import json
+from pathlib import Path
+
+
+def interval_intersection(a_start, a_end, b_start, b_end):
+    return max(0.0, min(a_end, b_end) - max(a_start, b_start))
+
+
+def interval_union(a_start, a_end, b_start, b_end):
+    return max(a_end, b_end) - min(a_start, b_start)
+
+
+def interval_iou(a_start, a_end, b_start, b_end):
+    inter = interval_intersection(a_start, a_end, b_start, b_end)
+    union = interval_union(a_start, a_end, b_start, b_end)
+    return inter / union if union > 0 else 0.0
+
+
+def best_match_for_gt(gt_segment, events):
+    gt_start, gt_end = gt_segment
+    best = None
+    for event in events:
+        inter = interval_intersection(gt_start, gt_end, event["start_time"], event["end_time"])
+        iou = interval_iou(gt_start, gt_end, event["start_time"], event["end_time"])
+        coverage = inter / max(gt_end - gt_start, 1e-8)
+        candidate = {
+            "event_id": int(event["event_id"]),
+            "pred_start": float(event["start_time"]),
+            "pred_end": float(event["end_time"]),
+            "pred_duration": float(event["duration_sec"]),
+            "pred_confidence": float(event["confidence"]),
+            "intersection": float(inter),
+            "iou": float(iou),
+            "gt_coverage": float(coverage),
+        }
+        if best is None or (candidate["intersection"], candidate["iou"], candidate["pred_confidence"]) > (
+            best["intersection"],
+            best["iou"],
+            best["pred_confidence"],
+        ):
+            best = candidate
+    return best
+
+
+def best_match_for_event(event, gt_segments):
+    best = None
+    for idx, (gt_start, gt_end) in enumerate(gt_segments):
+        inter = interval_intersection(gt_start, gt_end, event["start_time"], event["end_time"])
+        iou = interval_iou(gt_start, gt_end, event["start_time"], event["end_time"])
+        coverage = inter / max(event["duration_sec"], 1e-8)
+        candidate = {
+            "gt_index": idx,
+            "gt_start": float(gt_start),
+            "gt_end": float(gt_end),
+            "gt_duration": float(gt_end - gt_start),
+            "intersection": float(inter),
+            "iou": float(iou),
+            "pred_coverage": float(coverage),
+        }
+        if best is None or (candidate["intersection"], candidate["iou"]) > (
+            best["intersection"],
+            best["iou"],
+        ):
+            best = candidate
+    return best
+
+
+def official_matched_gt_indices(events, gt_segments):
+    matched = set()
+    for event in events:
+        overlaps = [
+            interval_intersection(event["start_time"], event["end_time"], gt_start, gt_end)
+            for gt_start, gt_end in gt_segments
+        ]
+        if overlaps and max(overlaps) > 0.0:
+            best_gt_index = max(range(len(overlaps)), key=lambda index: overlaps[index])
+            matched.add(best_gt_index)
+    return matched
+
+
+def write_csv(path, rows, fieldnames):
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--tag", default="fast_only")
+    args = parser.parse_args()
+
+    with open(args.input, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    missed_rows = []
+    fp_rows = []
+    matched_rows = []
+    overlap_only_rows = []
+
+    official_matched_total = 0
+
+    for video in data["videos"]:
+        video_id = video["video_id"]
+        video_path = video["video"]
+        gt_segments = [(float(seg["start"]), float(seg["end"])) for seg in video.get("ground_truth_segments", [])]
+        events = video["fast_only"]["events"]
+        official_matched = official_matched_gt_indices(events, gt_segments)
+        official_matched_total += len(official_matched)
+
+        for gt_index, gt_segment in enumerate(gt_segments):
+            best = best_match_for_gt(gt_segment, events) if events else None
+            any_overlap = bool(best and best["intersection"] > 0.0)
+            official_matched_flag = gt_index in official_matched
+            row = {
+                "video_id": video_id,
+                "video_path": video_path,
+                "gt_index": gt_index,
+                "gt_start": gt_segment[0],
+                "gt_end": gt_segment[1],
+                "gt_duration": gt_segment[1] - gt_segment[0],
+                "official_matched": official_matched_flag,
+                "any_overlap": any_overlap,
+                "best_event_id": "" if best is None else best["event_id"],
+                "best_pred_start": "" if best is None else best["pred_start"],
+                "best_pred_end": "" if best is None else best["pred_end"],
+                "best_pred_duration": "" if best is None else best["pred_duration"],
+                "best_pred_confidence": "" if best is None else best["pred_confidence"],
+                "best_intersection": 0.0 if best is None else best["intersection"],
+                "best_iou": 0.0 if best is None else best["iou"],
+                "best_gt_coverage": 0.0 if best is None else best["gt_coverage"],
+            }
+            if official_matched_flag:
+                matched_rows.append(row)
+            else:
+                missed_rows.append(row)
+                if any_overlap:
+                    overlap_only_rows.append(row)
+
+        for event in events:
+            best = best_match_for_event(event, gt_segments) if gt_segments else None
+            row = {
+                "video_id": video_id,
+                "video_path": video_path,
+                "event_id": int(event["event_id"]),
+                "pred_start": float(event["start_time"]),
+                "pred_end": float(event["end_time"]),
+                "pred_duration": float(event["duration_sec"]),
+                "pred_confidence": float(event["confidence"]),
+                "matched": bool(best and best["intersection"] > 0.0),
+                "best_gt_index": "" if best is None else best["gt_index"],
+                "best_gt_start": "" if best is None else best["gt_start"],
+                "best_gt_end": "" if best is None else best["gt_end"],
+                "best_gt_duration": "" if best is None else best["gt_duration"],
+                "best_intersection": 0.0 if best is None else best["intersection"],
+                "best_iou": 0.0 if best is None else best["iou"],
+                "best_pred_coverage": 0.0 if best is None else best["pred_coverage"],
+            }
+            if not row["matched"]:
+                fp_rows.append(row)
+
+    missed_rows.sort(key=lambda row: (row["gt_duration"], row["video_id"], row["gt_start"]), reverse=True)
+    fp_rows.sort(key=lambda row: (row["pred_confidence"], row["pred_duration"]), reverse=True)
+    matched_rows.sort(key=lambda row: (row["best_iou"], row["best_gt_coverage"]), reverse=True)
+    overlap_only_rows.sort(key=lambda row: (row["best_intersection"], row["best_iou"]), reverse=True)
+
+    prefix = output_dir / args.tag
+    missed_path = prefix.with_name(f"{args.tag}_missed_gt_events.csv")
+    fp_path = prefix.with_name(f"{args.tag}_false_positive_events.csv")
+    matched_path = prefix.with_name(f"{args.tag}_matched_gt_events.csv")
+    overlap_only_path = prefix.with_name(f"{args.tag}_missed_but_overlap_gt_events.csv")
+    summary_path = prefix.with_name(f"{args.tag}_failure_summary.json")
+
+    gt_fieldnames = [
+        "video_id", "video_path", "gt_index", "gt_start", "gt_end", "gt_duration", "official_matched",
+        "any_overlap", "best_event_id", "best_pred_start", "best_pred_end", "best_pred_duration",
+        "best_pred_confidence", "best_intersection", "best_iou", "best_gt_coverage",
+    ]
+    write_csv(missed_path, missed_rows, gt_fieldnames)
+    write_csv(matched_path, matched_rows, gt_fieldnames)
+    write_csv(overlap_only_path, overlap_only_rows, gt_fieldnames)
+    write_csv(fp_path, fp_rows, [
+        "video_id", "video_path", "event_id", "pred_start", "pred_end", "pred_duration", "pred_confidence",
+        "matched", "best_gt_index", "best_gt_start", "best_gt_end", "best_gt_duration",
+        "best_intersection", "best_iou", "best_pred_coverage",
+    ])
+
+    summary = {
+        "input": args.input,
+        "num_videos": len(data["videos"]),
+        "gt_segments_total": sum(len(v.get("ground_truth_segments", [])) for v in data["videos"]),
+        "predicted_events_total": sum(len(v["fast_only"]["events"]) for v in data["videos"]),
+        "official_matched_gt_events": official_matched_total,
+        "official_missed_gt_events": len(missed_rows),
+        "overlap_but_officially_missed_gt_events": len(overlap_only_rows),
+        "false_positive_events": len(fp_rows),
+        "top_missed_by_duration": missed_rows[:20],
+        "top_false_positives_by_confidence": fp_rows[:20],
+        "top_overlap_but_missed": overlap_only_rows[:20],
+        "top_matched_by_iou": matched_rows[:20],
+        "artifacts": {
+            "missed_gt_csv": str(missed_path),
+            "false_positive_csv": str(fp_path),
+            "matched_gt_csv": str(matched_path),
+            "missed_but_overlap_csv": str(overlap_only_path),
+        },
+    }
+    with open(summary_path, "w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2)
+
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/AI/slowfast/scripts/analyze_fp_score_distribution.py
+++ b/AI/slowfast/scripts/analyze_fp_score_distribution.py
@@ -1,0 +1,99 @@
+"""
+FP clip score distribution 분석.
+test_scores.json의 negative(label=0) 클립 스코어 분포 확인.
+- FP 이벤트는 negative 클립이 threshold 이상 스코어를 받아 형성되므로
+  negative 클립 score 분포가 FP 원인의 직접 지표.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+FOCAL_JSON  = PROJECT_ROOT / "outputs/train/overlap030_focal/test_scores.json"
+BASELINE_JSON = PROJECT_ROOT / "outputs/train/overlap051_e20/val_scores.json"
+
+START_SCORE = 0.47
+ROUTER_HIGH = 0.60
+BINS = [0.0, 0.20, 0.33, 0.40, 0.47, 0.60, 0.70, 0.80, 0.90, 1.01]
+BIN_LABELS = ["0.00~0.20","0.20~0.33","0.33~0.40","0.40~0.47",
+               "0.47~0.60","0.60~0.70","0.70~0.80","0.80~0.90","0.90~1.00"]
+
+
+def bin_scores(scores):
+    counts = [0] * len(BIN_LABELS)
+    for s in scores:
+        for i in range(len(BINS) - 1):
+            if BINS[i] <= s < BINS[i + 1]:
+                counts[i] += 1
+                break
+    return counts
+
+
+def print_divider(char="-", width=68):
+    print(char * width)
+
+
+def analyze(label, json_path):
+    with open(json_path) as f:
+        data = json.load(f)
+    rows = data["rows"]
+
+    neg = [r["fighting_prob"] for r in rows if r["label"] == 0]
+    pos = [r["fighting_prob"] for r in rows if r["label"] == 1]
+
+    print(f"\n{'='*68}")
+    print(f"  {label}")
+    print(f"  총 클립: {len(rows)}  |  negative: {len(neg)}  |  positive: {len(pos)}")
+    print(f"{'='*68}")
+
+    for name, scores in [("NEGATIVE (label=0)", neg), ("POSITIVE (label=1)", pos)]:
+        if not scores:
+            continue
+        total = len(scores)
+        above_start = sum(1 for s in scores if s >= START_SCORE)
+        gray_zone   = sum(1 for s in scores if START_SCORE <= s < ROUTER_HIGH)
+        above_high  = sum(1 for s in scores if s >= ROUTER_HIGH)
+
+        print(f"\n  [{name}]  n={total}")
+        print_divider()
+        print(f"  mean={sum(scores)/total:.3f}  "
+              f"min={min(scores):.3f}  max={max(scores):.3f}")
+        print()
+
+        # 핵심 구간 비율
+        print(f"  {'구간':<20} {'count':>7}  {'비율':>7}  {'누적':>7}")
+        print_divider()
+        cumulative = 0
+        counts = bin_scores(scores)
+        for bl, cnt in zip(BIN_LABELS, counts):
+            cumulative += cnt
+            marker = ""
+            if bl == "0.47~0.60":
+                marker = "  ← gray zone (VLM 라우팅)"
+            elif bl == "0.60~0.70":
+                marker = "  ← router_high 이상 (VLM 스킵)"
+            print(f"  {bl:<20} {cnt:>7}  {cnt/total*100:>6.1f}%  {cumulative/total*100:>6.1f}%{marker}")
+
+        print()
+        print(f"  >= start_score(0.47) : {above_start:>5} / {total}  ({above_start/total*100:.1f}%)")
+        print(f"  gray zone(0.47~0.60) : {gray_zone:>5} / {total}  ({gray_zone/total*100:.1f}%)")
+        print(f"  >= router_high(0.60) : {above_high:>5} / {total}  ({above_high/total*100:.1f}%)  ← VLM 못 봄")
+
+
+def main():
+    analyze("overlap030_focal  (test split)", FOCAL_JSON)
+
+    # baseline test_scores 없으면 val로 대체해서 참고용으로만
+    baseline_test = PROJECT_ROOT / "outputs/train/overlap051_e20/test_scores.json"
+    if baseline_test.exists():
+        analyze("overlap051_e20 baseline  (test split)", baseline_test)
+    else:
+        print("\n[baseline test_scores.json 없음 — val_scores로 참고 출력]")
+        analyze("overlap051_e20 baseline  (val split, 참고용)", BASELINE_JSON)
+
+
+if __name__ == "__main__":
+    main()

--- a/AI/slowfast/scripts/analyze_high_score_fp.py
+++ b/AI/slowfast/scripts/analyze_high_score_fp.py
@@ -1,0 +1,102 @@
+"""
+High-score FP 분석: overlap030_focal에서 0.60 이상 스코어를 받은 negative 클립을
+영상별로 분석해 어디서 FP가 집중되는지 파악.
+"""
+import json
+import sys
+from pathlib import Path
+from collections import defaultdict
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FOCAL_JSON = PROJECT_ROOT / "outputs/train/overlap030_focal/test_scores.json"
+FULLTEST_JSON = PROJECT_ROOT / "outputs/eval/fulltest_overlap030_focal_fastonly.json"
+
+THRESHOLDS = {"start_score": 0.47, "router_high": 0.60, "very_high": 0.70}
+
+
+def print_divider(char="-", width=72):
+    print(char * width)
+
+
+def main():
+    with open(FOCAL_JSON) as f:
+        score_data = json.load(f)
+
+    with open(FULLTEST_JSON) as f:
+        eval_data = json.load(f)
+
+    # event-level FP per video
+    event_fp = {v["video_id"]: v["false_positive"] for v in eval_data["per_video"]}
+
+    rows = score_data["rows"]
+    neg_rows = [r for r in rows if r["label"] == 0]
+    pos_rows = [r for r in rows if r["label"] == 1]
+
+    # 전체 요약
+    print("=" * 72)
+    print("  High-score FP 분석 (overlap030_focal, test split)")
+    print("=" * 72)
+    total_neg = len(neg_rows)
+    for name, thr in THRESHOLDS.items():
+        cnt = sum(1 for r in neg_rows if r["fighting_prob"] >= thr)
+        print(f"  negative >= {thr} ({name}): {cnt}/{total_neg} ({cnt/total_neg*100:.1f}%)")
+
+    # 영상별 집계
+    vid_stats = defaultdict(lambda: {"neg": [], "pos": [], "high_neg": [], "very_high_neg": []})
+    for r in neg_rows:
+        vid = r["video_id"]
+        vid_stats[vid]["neg"].append(r["fighting_prob"])
+        if r["fighting_prob"] >= THRESHOLDS["router_high"]:
+            vid_stats[vid]["high_neg"].append(r["fighting_prob"])
+        if r["fighting_prob"] >= THRESHOLDS["very_high"]:
+            vid_stats[vid]["very_high_neg"].append(r["fighting_prob"])
+    for r in pos_rows:
+        vid_stats[r["video_id"]]["pos"].append(r["fighting_prob"])
+
+    # 영상별 표: high_neg 많은 순 정렬
+    records = []
+    for vid, s in vid_stats.items():
+        records.append({
+            "video_id": vid,
+            "neg_total": len(s["neg"]),
+            "pos_total": len(s["pos"]),
+            "high_neg(>=0.60)": len(s["high_neg"]),
+            "very_high_neg(>=0.70)": len(s["very_high_neg"]),
+            "neg_mean": round(sum(s["neg"]) / len(s["neg"]), 3) if s["neg"] else 0,
+            "event_fp": event_fp.get(vid, 0),
+        })
+
+    df = pd.DataFrame(records).sort_values("high_neg(>=0.60)", ascending=False)
+
+    print(f"\n{'영상별 고스코어 negative 클립 (high_neg >= 0.60 내림차순)'}")
+    print_divider()
+    print(f"  {'video_id':<14} {'neg_tot':>7} {'pos_tot':>7} {'>=0.60':>7} {'>=0.70':>7} "
+          f"{'neg_mean':>8} {'event_fp':>8}")
+    print_divider()
+    for _, row in df.iterrows():
+        flag = " ***" if row["high_neg(>=0.60)"] >= 20 else (" **" if row["high_neg(>=0.60)"] >= 10 else "")
+        print(f"  {row['video_id']:<14} {row['neg_total']:>7} {row['pos_total']:>7} "
+              f"{row['high_neg(>=0.60)']:>7} {row['very_high_neg(>=0.70)']:>7} "
+              f"{row['neg_mean']:>8.3f} {row['event_fp']:>8}{flag}")
+
+    # 상위 FP 영상 요약
+    top = df[df["high_neg(>=0.60)"] >= 10]
+    print(f"\n  *** high_neg >= 20개,  ** >= 10개")
+    print(f"\n  [high_neg >= 10인 영상: {len(top)}개]")
+    print(f"  이 영상들의 high_neg 합계: {top['high_neg(>=0.60)'].sum()} / {df['high_neg(>=0.60)'].sum()} "
+          f"({top['high_neg(>=0.60)'].sum()/df['high_neg(>=0.60)'].sum()*100:.1f}%)")
+
+    # 집중도 분포
+    print(f"\n  [high_neg 분포]")
+    print_divider()
+    buckets = [(0, 0), (1, 4), (5, 9), (10, 19), (20, 999)]
+    for lo, hi in buckets:
+        label = f"{lo}~{hi}" if hi < 999 else f"{lo}+"
+        vids = df[(df["high_neg(>=0.60)"] >= lo) & (df["high_neg(>=0.60)"] <= hi)]
+        print(f"  {label:>8}개 영상: {len(vids):>3}개")
+
+
+if __name__ == "__main__":
+    main()

--- a/AI/slowfast/scripts/visualize_high_score_fp.py
+++ b/AI/slowfast/scripts/visualize_high_score_fp.py
@@ -1,0 +1,118 @@
+"""
+High-score FP 시각화.
+negative 클립(label=0) 중 score >= 0.60인 클립의 대표 프레임을 영상별로 저장.
+"""
+import json
+import sys
+from pathlib import Path
+from collections import defaultdict
+
+import cv2
+import numpy as np
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FOCAL_JSON  = PROJECT_ROOT / "outputs/train/overlap030_focal/test_scores.json"
+TEST_CSV    = PROJECT_ROOT / "data/manifests/cctv_x3d_s_overlap030/testing_clips.csv"
+OUTPUT_DIR  = PROJECT_ROOT / "outputs/viz/high_score_fp"
+
+HIGH_THR = 0.60
+TOP_N_VIDEOS = 8       # 상위 몇 개 영상 시각화
+CLIPS_PER_VIDEO = 10  # 영상당 몇 개 클립
+THUMB_W, THUMB_H = 224, 224
+
+
+def extract_middle_frame(video_path, start_frame, end_frame):
+    cap = cv2.VideoCapture(str(video_path))
+    mid = (start_frame + end_frame) // 2
+    cap.set(cv2.CAP_PROP_POS_FRAMES, mid)
+    ret, frame = cap.read()
+    cap.release()
+    if not ret:
+        return np.zeros((THUMB_H, THUMB_W, 3), dtype=np.uint8)
+    return cv2.resize(frame, (THUMB_W, THUMB_H))
+
+
+def make_grid(frames, scores, times, cols=5):
+    rows = (len(frames) + cols - 1) // cols
+    cell_h = THUMB_H + 30
+    cell_w = THUMB_W + 4
+    canvas = np.zeros((rows * cell_h, cols * cell_w, 3), dtype=np.uint8) + 30
+
+    for idx, (frame, score, t) in enumerate(zip(frames, scores, times)):
+        r, c = divmod(idx, cols)
+        y, x = r * cell_h, c * cell_w
+        canvas[y:y + THUMB_H, x:x + THUMB_W] = frame
+        # score에 따라 테두리 색: 0.80+ 빨강, 0.60~0.80 주황
+        color = (0, 0, 220) if score >= 0.80 else (0, 140, 255)
+        cv2.rectangle(canvas, (x, y), (x + THUMB_W - 1, y + THUMB_H - 1), color, 2)
+        label = f"t={t:.0f}s  {score:.3f}"
+        cv2.putText(canvas, label, (x + 3, y + THUMB_H + 20),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.45, (200, 200, 200), 1)
+    return canvas
+
+
+def main():
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    with open(FOCAL_JSON) as f:
+        score_data = json.load(f)
+
+    df_manifest = pd.read_csv(TEST_CSV)
+    manifest_map = {row["clip_id"]: row for _, row in df_manifest.iterrows()}
+
+    # high-score negative 클립 수집
+    vid_clips = defaultdict(list)
+    for r in score_data["rows"]:
+        if r["label"] == 0 and r["fighting_prob"] >= HIGH_THR:
+            cid = r["clip_id"]
+            if cid in manifest_map:
+                meta = manifest_map[cid]
+                vid_clips[r["video_id"]].append({
+                    "clip_id": cid,
+                    "score": r["fighting_prob"],
+                    "start_frame": int(meta["start_frame"]),
+                    "end_frame": int(meta["end_frame"]),
+                    "start_time": float(meta["start_time"]),
+                    "video_path": meta["video_path"],
+                })
+
+    # high_neg 많은 순 정렬 → 상위 N개 영상
+    sorted_vids = sorted(vid_clips.keys(), key=lambda v: len(vid_clips[v]), reverse=True)
+    top_vids = sorted_vids[:TOP_N_VIDEOS]
+
+    print(f"시각화 대상: {len(top_vids)}개 영상")
+    for vid in top_vids:
+        clips = sorted(vid_clips[vid], key=lambda c: c["score"], reverse=True)
+        selected = clips[:CLIPS_PER_VIDEO]
+
+        print(f"  [{vid}] high_neg={len(vid_clips[vid])}개 → {len(selected)}개 클립 추출 중...")
+
+        frames, scores, times = [], [], []
+        for clip in selected:
+            frame = extract_middle_frame(clip["video_path"], clip["start_frame"], clip["end_frame"])
+            frames.append(frame)
+            scores.append(clip["score"])
+            times.append(clip["start_time"])
+
+        if not frames:
+            continue
+
+        grid = make_grid(frames, scores, times, cols=5)
+
+        # 헤더 추가
+        header = np.zeros((40, grid.shape[1], 3), dtype=np.uint8) + 20
+        title = f"{vid}  |  high_neg(>=0.60): {len(vid_clips[vid])}  |  showing top-{len(selected)} by score"
+        cv2.putText(header, title, (8, 27), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 220, 100), 1)
+        full = np.vstack([header, grid])
+
+        out_path = OUTPUT_DIR / f"{vid}_high_fp.jpg"
+        cv2.imwrite(str(out_path), full)
+        print(f"    saved → {out_path}")
+
+    print(f"\n완료: {OUTPUT_DIR}")
+    print("범례: 빨간 테두리=score>=0.80, 주황=0.60~0.80")
+
+
+if __name__ == "__main__":
+    main()

--- a/AI/slowfast/scripts/visualize_val_high_score_neg.py
+++ b/AI/slowfast/scripts/visualize_val_high_score_neg.py
@@ -1,0 +1,116 @@
+"""
+Val split high-score negative 클립 시각화.
+Type 분류(A/B/C/D) 판단을 위해 영상별 고득점 negative 클립 대표 프레임 저장.
+"""
+import json
+from pathlib import Path
+from collections import defaultdict
+
+import cv2
+import numpy as np
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+VAL_JSON     = PROJECT_ROOT / "outputs/train/overlap030_focal/val_scores.json"
+VAL_CSV      = PROJECT_ROOT / "data/manifests/cctv_x3d_s_overlap030/validation_clips.csv"
+OUTPUT_DIR   = PROJECT_ROOT / "outputs/viz/val_high_score_neg"
+
+HIGH_THR        = 0.60
+TOP_N_VIDEOS    = 12
+CLIPS_PER_VIDEO = 10
+THUMB_W, THUMB_H = 224, 224
+
+
+def extract_middle_frame(video_path, start_frame, end_frame):
+    cap = cv2.VideoCapture(str(video_path))
+    mid = (start_frame + end_frame) // 2
+    cap.set(cv2.CAP_PROP_POS_FRAMES, mid)
+    ret, frame = cap.read()
+    cap.release()
+    if not ret:
+        return np.zeros((THUMB_H, THUMB_W, 3), dtype=np.uint8)
+    return cv2.resize(frame, (THUMB_W, THUMB_H))
+
+
+def make_grid(frames, scores, times, cols=5):
+    rows = (len(frames) + cols - 1) // cols
+    cell_h = THUMB_H + 30
+    cell_w = THUMB_W + 4
+    canvas = np.zeros((rows * cell_h, cols * cell_w, 3), dtype=np.uint8) + 30
+
+    for idx, (frame, score, t) in enumerate(zip(frames, scores, times)):
+        r, c = divmod(idx, cols)
+        y, x = r * cell_h, c * cell_w
+        canvas[y:y + THUMB_H, x:x + THUMB_W] = frame
+        color = (0, 0, 220) if score >= 0.80 else (0, 140, 255)
+        cv2.rectangle(canvas, (x, y), (x + THUMB_W - 1, y + THUMB_H - 1), color, 2)
+        label = f"t={t:.0f}s  {score:.3f}"
+        cv2.putText(canvas, label, (x + 3, y + THUMB_H + 20),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.45, (200, 200, 200), 1)
+    return canvas
+
+
+def main():
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    with open(VAL_JSON) as f:
+        score_data = json.load(f)
+
+    df_manifest = pd.read_csv(VAL_CSV)
+    manifest_map = {row["clip_id"]: row for _, row in df_manifest.iterrows()}
+
+    vid_clips = defaultdict(list)
+    for r in score_data["rows"]:
+        if r["label"] == 0 and r["fighting_prob"] >= HIGH_THR:
+            cid = r["clip_id"]
+            if cid in manifest_map:
+                meta = manifest_map[cid]
+                vid_clips[r["video_id"]].append({
+                    "clip_id": cid,
+                    "score": r["fighting_prob"],
+                    "start_frame": int(meta["start_frame"]),
+                    "end_frame": int(meta["end_frame"]),
+                    "start_time": float(meta["start_time"]),
+                    "video_path": meta["video_path"],
+                })
+
+    sorted_vids = sorted(vid_clips.keys(), key=lambda v: len(vid_clips[v]), reverse=True)
+    top_vids = sorted_vids[:TOP_N_VIDEOS]
+
+    print(f"시각화 대상: {len(top_vids)}개 영상 (high_neg >= {HIGH_THR})")
+    print(f"{'영상':<20} {'high_neg':>10} {'neg_total':>10}")
+    for vid in top_vids:
+        total_neg = sum(1 for r in score_data["rows"] if r["video_id"] == vid and r["label"] == 0)
+        print(f"  {vid:<18} {len(vid_clips[vid]):>10} {total_neg:>10}")
+
+    print()
+    for vid in top_vids:
+        clips = sorted(vid_clips[vid], key=lambda c: c["score"], reverse=True)
+        selected = clips[:CLIPS_PER_VIDEO]
+
+        print(f"  [{vid}] {len(selected)}개 클립 추출 중...")
+
+        frames, scores, times = [], [], []
+        for clip in selected:
+            frame = extract_middle_frame(clip["video_path"], clip["start_frame"], clip["end_frame"])
+            frames.append(frame)
+            scores.append(clip["score"])
+            times.append(clip["start_time"])
+
+        grid = make_grid(frames, scores, times, cols=5)
+
+        header = np.zeros((40, grid.shape[1], 3), dtype=np.uint8) + 20
+        title = f"{vid}  |  high_neg(>={HIGH_THR}): {len(vid_clips[vid])}  |  top-{len(selected)} by score"
+        cv2.putText(header, title, (8, 27), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 220, 100), 1)
+        full = np.vstack([header, grid])
+
+        out_path = OUTPUT_DIR / f"{vid}_val_high_neg.jpg"
+        cv2.imwrite(str(out_path), full)
+        print(f"    saved → {out_path}")
+
+    print(f"\n완료: {OUTPUT_DIR}")
+    print("범례: 빨간 테두리=score>=0.80, 주황=0.60~0.80")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🔍 Background

overlap030_focal 기반 fast scorer는
weak/subtle violence recovery 측면에서는 개선된 성능을 보였지만,
동시에 high-score false positive 증가 문제가 확인됨.

특히 overlap030_focal full testing 결과:

* recall 증가
* TP 증가
* weak fight recovery 개선

효과는 확인되었으나,

* high-score FP 증가
* event fragmentation
* FP split 증가

문제가 함께 발생함.

추가 분석 결과:

* negative clip 중 상당수가 `router_high` 이상 score를 출력하고 있었음
* 일부 FP clip은 gray-zone 진입 없이 바로 high-confidence fight score를 출력하고 있었음
* clip-level suppress-only refinement만으로는 이러한 FP를 충분히 억제하지 못하는 한계가 존재했음

또한 FP 사례 분석 결과:

* 극단적으로 화질이 낮은 영상
* 심한 움직임 블러
* 폭행 직후 상황
* 사람들이 몰려드는 상황
* 대치 / 제압 상황

등 다양한 failure pattern이 존재함이 확인됨.

이에 따라 기존:

* clip 단위 binary refinement

중심 구조 대신,

* event-level semantic verification
* event-level VLM refinement
* semantic event validation

기반 구조로 refinement 방향 재설계 진행함.

---

## 🎯 Main Changes

### High-score FP Distribution 분석

* negative clip score distribution 분석
* `router_high` 이상 high-score FP 비율 확인
* gray-zone bypass FP 비율 분석
* 영상별 FP 집중도 분석 수행

### Type A/B/C/D 기반 FP 유형 분석

#### Type A — 도메인 / 화질 한계

* 극단적으로 낮은 화질
* 심한 움직임 블러
* 야간 환경
* 강한 조명 / 헤드라이트
* 카메라 흔들림

#### Type B — 폭행 직후 상황

* 폭행 이후 사람들이 몰려드는 장면
* 피해자를 부축하거나 이동시키는 장면
* 제압 / 수갑 장면

#### Type C — 가림 / 부분 관측 문제

* 군중 일부가 벽이나 장애물에 가려짐
* 일부 사람만 부분적으로 관측 가능

#### Type D — 경계가 모호한 행동

* 말다툼
* 삿대질
* 멱살잡이
* 폭행 직전 행동

---

### clip-level Refinement 한계 분석

기존 구조:

Clip
→ Selective VLM Refinement
→ Score Fusion
→ Event Detection

문제점:

* VLM이 이벤트 중간 clip score를 낮추는 경우 발생
* 하나의 이벤트가 여러 개로 split됨
* fragmented FP event 증가
* high-confidence FP는 VLM routing 이전 단계에서 이미 통과

---

### event-level VLM Refinement 구조 재설계

기존 구조:

Clip
→ Selective VLM Refinement
→ Score Fusion
→ Event Detection

재설계 방향:

Clip
→ Fast Event Generation
→ Event-level Semantic Verification
→ Event-level VLM Refinement
→ Final Event Decision

핵심 변경점:

* clip 단위 판단 대신 event 전체 단위 semantic 판단 수행
* VLM이 이벤트 전체를 보고:

  * 실제 폭행 상황인지
  * 폭행 이후 상황인지
  * 단순 군중 이동인지
    한 번만 판단하도록 구조 변경

이를 통해:

* event fragmentation 감소
* FP split 감소
* Type B 계열 FP 감소

가능성 검토 진행함.

---

## 📊 Experiment Notes

* overlap030_focal은 recall 측면에서는 개선되었지만,
  동시에 FP 증가 문제도 함께 발생함

* negative clip 중 high-score FP 비율이 높아,
  clip-level suppress-only refinement만으로는 FP 억제가 어려운 문제 확인됨

* 일부 FP 영상은:

  * 극단적으로 낮은 화질
  * 심한 움직임 블러
  * 강한 조명 환경
    등 사람도 판단 어려운 특성을 보임

* 일부 FP는:

  * 폭행 직후 상황
  * 군중이 몰려드는 장면
  * 제압 / 대치 상황
    등 semantic ambiguity 특성을 보임

* 기존 clip-level refinement 구조는:

  * 이벤트 중간 clip suppression
  * event fragmentation
  * FP split 증가
    문제를 유발할 수 있음이 확인됨

* event-level semantic verification 기반 refinement 구조로 pipeline 재설계 및 초기 구현 진행
